### PR TITLE
Refactor to prevent mod-lists from accessing FQM schema

### DIFF
--- a/src/main/java/org/folio/fqm/lib/FQM.java
+++ b/src/main/java/org/folio/fqm/lib/FQM.java
@@ -1,7 +1,6 @@
 package org.folio.fqm.lib;
 
 import org.folio.fql.FqlService;
-import org.folio.fqm.lib.repository.MetaDataRepository;
 import org.folio.fqm.lib.service.FqmMetaDataService;
 import org.folio.fqm.lib.service.QueryProcessorService;
 import org.folio.fqm.lib.service.QueryResultsSorterService;
@@ -32,8 +31,8 @@ public class FQM {
     return new QueryResultsSorterService(dataSource);
   }
 
-  public static FqlValidationService fqlValidationService(DataSource dataSource) {
-    return new FqlValidationService(new FqlService(), new MetaDataRepository(dataSource));
+  public static FqlValidationService fqlValidationService() {
+    return new FqlValidationService(new FqlService());
   }
 
   public static FqlService fqlService() {

--- a/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
@@ -76,6 +76,18 @@ public class IdStreamer {
     return streamIdsInBatch(entityType, derivedTable, sortResults, condition, batchSize, idsConsumer);
   }
 
+  public List<UUID> getSortedIds(String derivedTableName, EntityType entityType,
+                                 Condition sqlWhereClause, int offset, int batchSize) {
+    return jooqContext.dsl()
+        .select(field(ID_FIELD_NAME))
+        .from(derivedTableName)
+        .where(sqlWhereClause)
+        .orderBy(getSortFields(entityType, true))
+        .offset(offset)
+        .limit(batchSize)
+        .fetchInto(UUID.class);
+    }
+
   private int streamIdsInBatch(EntityType entityType,
                                String derivedTableName,
                                boolean sortResults,

--- a/src/main/java/org/folio/fqm/lib/service/FqlValidationService.java
+++ b/src/main/java/org/folio/fqm/lib/service/FqlValidationService.java
@@ -6,28 +6,17 @@ import org.folio.fql.model.AndCondition;
 import org.folio.fql.model.FieldCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
-import org.folio.fqm.lib.exception.EntityTypeNotFoundException;
-import org.folio.fqm.lib.repository.MetaDataRepository;
 import org.folio.querytool.domain.dto.EntityType;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 public class FqlValidationService {
 
   private final FqlService fqlService;
 
-  private final MetaDataRepository metaDataRepository;
-
-  public FqlValidationService(FqlService fqlService, MetaDataRepository metaDataRepository) {
+  public FqlValidationService(FqlService fqlService) {
     this.fqlService = fqlService;
-    this.metaDataRepository = metaDataRepository;
-  }
-
-  public Map<String, String> validateFql(String tenantId, UUID entityTypeId, String fqlCriteria) {
-    EntityType entityType = getEntityType(tenantId, entityTypeId);
-    return validateFql(entityType, fqlCriteria);
   }
 
   public Map<String, String> validateFql(EntityType entityType, String fqlCriteria) {
@@ -59,10 +48,5 @@ public class FqlValidationService {
         );
     }
     return errorMap;
-  }
-
-  private EntityType getEntityType(String tenantId, UUID entityTypeId) {
-    return metaDataRepository.getEntityTypeDefinition(tenantId, entityTypeId)
-      .orElseThrow(() -> new EntityTypeNotFoundException(entityTypeId));
   }
 }

--- a/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
@@ -5,6 +5,8 @@ import org.folio.fqm.lib.model.IdsWithCancelCallback;
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fqm.lib.repository.dataproviders.IdStreamerTestDataProvider;
+import org.folio.querytool.domain.dto.EntityType;
+import org.jooq.Condition;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.tools.jdbc.MockConnection;
@@ -17,6 +19,10 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.folio.fqm.lib.repository.MetaDataRepository.ID_FIELD_NAME;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.table;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -57,6 +63,22 @@ class IdStreamerTest {
     int idsCount = idStreamer.streamIdsInBatch(TENANT_ID, ENTITY_TYPE_ID, true, fql, 2, idsConsumer);
     assertEquals(IdStreamerTestDataProvider.TEST_CONTENT_IDS, actualList, "Expected List should equal Actual List");
     assertEquals(IdStreamerTestDataProvider.TEST_CONTENT_IDS.size(), idsCount);
+  }
+
+  @Test
+  void shouldGetSortedIds() {
+    UUID queryId = UUID.randomUUID();
+    int offset = 0;
+    int limit = 0;
+    String derivedTableName = "table_01";
+    EntityType entityType = new EntityType().name("test-entity");
+    Condition condition = field(ID_FIELD_NAME).in(
+      select(field("result_id"))
+        .from(table("Tenant_01_mod_fqm_manager.query_results"))
+        .where(field("query_id").eq(queryId))
+    );
+    List<UUID> actualIds = idStreamer.getSortedIds(derivedTableName, entityType, condition, offset, limit);
+    assertEquals(IdStreamerTestDataProvider.TEST_CONTENT_IDS, actualIds);
   }
 
   @Test

--- a/src/test/java/org/folio/fqm/lib/repository/dataproviders/IdStreamerTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/lib/repository/dataproviders/IdStreamerTestDataProvider.java
@@ -37,6 +37,7 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
   private static final String DERIVED_TABLE_NAME_QUERY_REGEX = "SELECT DERIVED_TABLE_NAME FROM .*\\.ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String ENTITY_TYPE_DEFINITION_REGEX = "SELECT DEFINITION FROM .*\\.ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String GET_IDS_QUERY_REGEX = "SELECT ID FROM .*_MOD_FQM_MANAGER\\..* WHERE .* ORDER BY ID ASC";
+  private static final String GET_SORTED_IDS_QUERY_REGEX = "SELECT ID FROM .* WHERE ID IN \\(SELECT RESULT_ID FROM .*_MOD_FQM_MANAGER.QUERY_RESULTS WHERE QUERY_ID = .*";
   private static final String GET_ENTITY_TYPE_ID_FROM_QUERY_ID_REGEX = "SELECT ENTITY_TYPE_ID FROM .*.QUERY_DETAILS WHERE QUERY_ID = .*";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -57,7 +58,7 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
       Result<Record1<Object>> result = create.newResult(definitionField);
       result.add(create.newRecord(definitionField).values(writeValueAsString(TEST_ENTITY_TYPE_DEFINITION)));
       mockResult = new MockResult(1, result);
-    } else if (sql.matches(GET_IDS_QUERY_REGEX)) {
+    } else if (sql.matches(GET_IDS_QUERY_REGEX) || sql.matches(GET_SORTED_IDS_QUERY_REGEX)) {
       Result<Record1<Object>> result = create.newResult(DSL.field(MetaDataRepository.ID_FIELD_NAME));
       TEST_CONTENT_IDS.forEach(id -> result.add(create.newRecord(DSL.field(MetaDataRepository.ID_FIELD_NAME)).values(id)));
       mockResult = new MockResult(1, result);

--- a/src/test/java/org/folio/fqm/lib/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fqm/lib/service/FqlValidationServiceTest.java
@@ -2,7 +2,9 @@ package org.folio.fqm.lib.service;
 
 import org.folio.fql.FqlService;
 import org.folio.fqm.lib.repository.MetaDataRepository;
-import org.folio.querytool.domain.dto.*;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.folio.querytool.domain.dto.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +13,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +39,7 @@ class FqlValidationServiceTest {
   @BeforeEach
   public void setup() {
     MetaDataRepository metaDataRepository = mock(MetaDataRepository.class);
-    this.fqlValidationService = new FqlValidationService(new FqlService(), metaDataRepository);
+    this.fqlValidationService = new FqlValidationService(new FqlService());
     when(metaDataRepository.getEntityTypeDefinition(TENANT_ID, ENTITY_TYPE_ID)).thenReturn(Optional.of(entityType));
   }
 
@@ -46,7 +49,7 @@ class FqlValidationServiceTest {
       {"field1": {"$eq": "some value"}}
       """;
     Map<String, String> expectedErrors = Map.of();
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, fqlCondition);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(expectedErrors, actualErrors);
   }
 
@@ -71,7 +74,7 @@ class FqlValidationServiceTest {
       }
       """;
     Map<String, String> expectedErrors = Map.of();
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, complexFql);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, complexFql);
     assertEquals(expectedErrors, actualErrors);
   }
 
@@ -80,7 +83,7 @@ class FqlValidationServiceTest {
     String fqlCondition = """
       {"field1": {"$eq": "some value"}
       """;
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, fqlCondition);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(1, actualErrors.size());
     assertTrue(actualErrors.containsKey(fqlCondition) && actualErrors.get(fqlCondition) != null);
   }
@@ -92,7 +95,7 @@ class FqlValidationServiceTest {
       """;
     String expectedErrorMessage = "Condition {\"$xy\":\"some value\"} contains an invalid operator";
     Map<String, String> expectedErrors = Map.of("field1", expectedErrorMessage);
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, fqlCondition);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(expectedErrors, actualErrors);
   }
 
@@ -103,7 +106,7 @@ class FqlValidationServiceTest {
       """;
     String expectedErrorMessage = "Field field4 is not present in definition of entity type " + entityType.getName();
     Map<String, String> expectedErrors = Map.of("field4", expectedErrorMessage);
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, fqlCondition);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(expectedErrors, actualErrors);
   }
 
@@ -123,7 +126,7 @@ class FqlValidationServiceTest {
       "field4", expectedErrorMessage1,
       "field5", expectedErrorMessage2
     );
-    Map<String, String> actualErrors = fqlValidationService.validateFql(TENANT_ID, ENTITY_TYPE_ID, fqlCondition);
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(expectedErrors, actualErrors);
   }
 }

--- a/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
+++ b/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
@@ -3,28 +3,35 @@ package org.folio.fqm.lib.service;
 import org.folio.fqm.lib.model.IdsWithCancelCallback;
 import org.folio.fqm.lib.repository.IdStreamer;
 import org.folio.fqm.lib.repository.MetaDataRepository;
+import org.folio.querytool.domain.dto.EntityType;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
+import static org.folio.fqm.lib.repository.MetaDataRepository.ID_FIELD_NAME;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.select;
-import static org.mockito.Mockito.*;
+import static org.jooq.impl.DSL.table;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 
 class QueryResultsSorterServiceTest {
-  private QueryResultsSorterService queryResultsService;
+  private QueryResultsSorterService queryResultsSorterService;
   private IdStreamer idStreamer;
 
   @BeforeEach
   void setup() {
     idStreamer = mock(IdStreamer.class);
-    this.queryResultsService = new QueryResultsSorterService(idStreamer);
+    this.queryResultsSorterService = new QueryResultsSorterService(idStreamer);
   }
 
   @Test
@@ -40,7 +47,7 @@ class QueryResultsSorterServiceTest {
     IntConsumer totalCountConsumer = mock(IntConsumer.class);
     Consumer<Throwable> errorConsumer = mock(Consumer.class);
 
-    queryResultsService.streamSortedIds(
+    queryResultsSorterService.streamSortedIds(
       tenantId,
       queryId,
       batchSize,
@@ -56,5 +63,24 @@ class QueryResultsSorterServiceTest {
         batchSize,
         idsConsumer
       );
+  }
+
+  @Test
+  void shouldGetSortedIds() {
+    String tenantId = "tenant_01";
+    UUID queryId = UUID.randomUUID();
+    int offset = 0;
+    int limit = 0;
+    String derivedTableName = "table_01";
+    EntityType entityType = new EntityType().name("test-entity");
+    Condition condition = field(ID_FIELD_NAME).in(
+      select(field("result_id"))
+        .from(table("tenant_01_mod_fqm_manager.query_results"))
+        .where(field("query_id").eq(queryId))
+    );
+    List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    when(idStreamer.getSortedIds(derivedTableName, entityType, condition, offset, limit)).thenReturn(expectedIds);
+    List<UUID> actualIds = queryResultsSorterService.getSortedIds(tenantId, queryId, derivedTableName, entityType, offset, limit);
+    assertEquals(expectedIds, actualIds);
   }
 }


### PR DESCRIPTION
## Purpose
[US1151239](https://rally1.rallydev.com/#/?detail=/userstory/719697203519&fdp=true): mod-list-app: Use the FQM API instead of going to its DB schema

Implementation of above ticket requires these changes in lib-fqm-query-processor

## Testing
- [x] All unit tests passed