### PR TITLE
Add logic to handle PgArrays to allow for reporting on User's departments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <org.projectlombok.verion>1.18.28</org.projectlombok.verion>
     <org.apache.logging.log4j.version>2.20.0</org.apache.logging.log4j.version>
     <org.apache.commons.version>4.4</org.apache.commons.version>
+    <org.postgresql.version>42.5.4</org.postgresql.version>
   </properties>
 
   <scm>
@@ -206,6 +207,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <version>${org.apache.commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${org.postgresql.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/folio/fqm/lib/repository/ResultSetRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/ResultSetRepositoryTest.java
@@ -62,6 +62,19 @@ class ResultSetRepositoryTest {
   }
 
   @Test
+  void getResultSetShouldHandleArray() {
+    List<UUID> listIds = List.of(UUID.randomUUID());
+    List<String> fields = List.of("id", "testField");
+    List<Map<String, Object>> expectedFullList = ResultSetRepositoryTestDataProvider.TEST_ENTITY_WITH_ARRAY_CONTENTS;
+    List<Map<String, Object>> expectedList = List.of(
+      Map.of("id", expectedFullList.get(0).get("id"), "testField", List.of("value1"))
+    );
+    List<Map<String, Object>> actualList = repo.getResultSet("tenant_02", UUID.randomUUID(), fields, listIds);
+    assertEquals(expectedList.get(0).get("id"), actualList.get(0).get("id"));
+    assertEquals(expectedList.get(0).get("arrayField"), actualList.get(0).get("arrayField"));
+  }
+
+  @Test
   void shouldRunSynchronousQueryAndReturnContents() {
     String tenantId = "tenant_01";
     UUID entityTypeId = UUID.randomUUID();


### PR DESCRIPTION
## Purpose
Add logic to handle PgArrays to allow for reporting on User's departments. Department ids and names are stored as PgArrays. This ticket adds logic to extract the actual array object from a pgarray, rather than returning the entire PgArray (which contains a lot of extra unneeded data).

## Testing
- [x] All unit tests passed (including new test for extracting array from pgarray)
- [x] Query processor library works with mod-fqm-manager, allowing array fields to be correctly extracted from database:
<img width="895" alt="Screenshot 2023-09-06 at 12 12 06 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/d1e23b2f-c4fd-4b7f-9944-6d4e0abe613d">
