### PR TITLE
LIBFQMQUER-2: Create contains operator to handle arrays

### DIFF
--- a/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
+++ b/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
@@ -40,7 +40,8 @@ public class ConditionDeserializer extends StdScalarDeserializer<FqlCondition<?>
     IS_GTE, GTE_DESERIALIZER,
     IS_LT, LT_DESERIALIZER,
     IS_LTE, LTE_DESERIALIZER,
-    IS_REGEX, REGEX_DESERIALIZER
+    IS_REGEX, REGEX_DESERIALIZER,
+    IS_CONTAINS, CONTAINS_DESERIALIZER
   );
 
   private final ObjectMapper mapper;

--- a/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
+++ b/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
@@ -11,6 +11,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static org.folio.fql.model.ContainsCondition.$CONTAINS;
 import static org.folio.fql.model.EqualsCondition.$EQ;
 import static org.folio.fql.model.NotEqualsCondition.$NE;
 import static org.folio.fql.model.GreaterThanCondition.$GT;
@@ -32,7 +33,8 @@ public class DeserializerFunctions {
     IS_GTE(node -> node.has($GTE) && node.get($GTE).isValueNode()),
     IS_LT(node -> node.has($LT) && node.get(LessThanCondition.$LT).isValueNode()),
     IS_LTE(node -> node.has($LTE) && node.get($LTE).isValueNode()),
-    IS_REGEX(node -> node.has($REGEX) && node.get($REGEX).isTextual());
+    IS_REGEX(node -> node.has($REGEX) && node.get($REGEX).isTextual()),
+    IS_CONTAINS(node -> node.has($CONTAINS) && node.get($CONTAINS).isValueNode());
 
     final Predicate<JsonNode> predicate;
 
@@ -60,7 +62,8 @@ public class DeserializerFunctions {
     GTE_DESERIALIZER((field, node) -> new GreaterThanCondition(field, true, convertValue(node.get($GTE)))),
     LT_DESERIALIZER((field, node) -> new LessThanCondition(field, false, convertValue(node.get($LT)))),
     LTE_DESERIALIZER((field, node) -> new LessThanCondition(field, true, convertValue(node.get($LTE)))),
-    REGEX_DESERIALIZER((field, node) -> new RegexCondition(field, node.get($REGEX).textValue()));
+    REGEX_DESERIALIZER((field, node) -> new RegexCondition(field, node.get($REGEX).textValue())),
+    CONTAINS_DESERIALIZER((field, node) -> new ContainsCondition(field, convertValue(node.get($CONTAINS))));
 
     final BiFunction<String, JsonNode, FieldCondition<?>> deserializer;
 

--- a/src/main/java/org/folio/fql/model/ContainsCondition.java
+++ b/src/main/java/org/folio/fql/model/ContainsCondition.java
@@ -1,0 +1,5 @@
+package org.folio.fql.model;
+
+public record ContainsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+  public static final String $CONTAINS = "$contains";
+}

--- a/src/main/java/org/folio/fql/model/FieldCondition.java
+++ b/src/main/java/org/folio/fql/model/FieldCondition.java
@@ -1,6 +1,6 @@
 package org.folio.fql.model;
 
 public sealed interface FieldCondition<T> extends FqlCondition<T> permits EqualsCondition, GreaterThanCondition,
-  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition {
+  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition {
   String fieldName();
 }

--- a/src/main/java/org/folio/fqm/lib/repository/FqlToSqlConverter.java
+++ b/src/main/java/org/folio/fqm/lib/repository/FqlToSqlConverter.java
@@ -35,7 +35,8 @@ public class FqlToSqlConverter {
     GreaterThanCondition.class, (cnd, ent) -> handleGreaterThan((GreaterThanCondition) cnd, ent),
     LessThanCondition.class, (cnd, ent) -> handleLessThan((LessThanCondition) cnd, ent),
     AndCondition.class, (cnd, ent) -> handleAnd((AndCondition) cnd, ent),
-    RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd, ent)
+    RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd, ent),
+    ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent)
   );
 
   /**
@@ -185,6 +186,13 @@ public class FqlToSqlConverter {
   private Condition handleRegEx(RegexCondition regExCondition, EntityType entityType) {
     // perform case-insensitive regex search
     return condition("{0} ~* {1}", field(regExCondition, entityType), val(regExCondition.value()));
+  }
+
+  private Condition handleContains(ContainsCondition containsCondition, EntityType entityType) {
+    if (containsCondition.value() instanceof String s) {
+      return field(containsCondition, entityType).containsIgnoreCase(s);
+    }
+    return field(containsCondition, entityType).contains(containsCondition.value());
   }
 
   private Field<Object> field(FieldCondition<?> condition, EntityType entityType) {

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerContainsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerContainsTest.java
@@ -1,0 +1,54 @@
+package org.folio.fql.deserializer;
+
+import org.folio.fql.FqlService;
+import org.folio.fql.model.ContainsCondition;
+import org.folio.fql.model.Fql;
+import org.folio.fql.model.FqlCondition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FqlDeserializerContainsTest {
+
+  private FqlService fqlService;
+
+  @BeforeEach
+  void setup() {
+    fqlService = new FqlService();
+  }
+
+  @Test
+  void shouldGetSimpleContainsFqlWithStringValue() {
+    String simpleStringJson =
+      """
+         {"arrayField1": {"$contains": "value"}}
+        """;
+    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", "value");
+    Fql expectedFql = new Fql(fqlCondition);
+    Fql actualFql = fqlService.getFql(simpleStringJson);
+    assertEquals(expectedFql, actualFql);
+  }
+
+  @Test
+  void shouldGetSimpleContainsFqlWithIntegerValue() {
+    String simpleContainsJson =
+      """
+        {"arrayField1": {"$contains": 11}}
+        """;
+    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", 11);
+    Fql expectedFql = new Fql(fqlCondition);
+    Fql actualFql = fqlService.getFql(simpleContainsJson);
+    assertEquals(expectedFql, actualFql);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenContainsConditionIsNotValueNode() {
+    String invalidEqualsConditionJson =
+      """
+        {"arrayField1": {"contains": ["value1", "value2", "value3" ] }}
+        """;
+    assertThrows(FqlParsingException.class, () -> fqlService.getFql(invalidEqualsConditionJson));
+  }
+}

--- a/src/test/java/org/folio/fqm/lib/repository/FqlToSqlConverterTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/FqlToSqlConverterTest.java
@@ -1,6 +1,7 @@
 package org.folio.fqm.lib.repository;
 
 import org.folio.fqm.lib.exception.ColumnNotFoundException;
+import org.folio.querytool.domain.dto.ArrayType;
 import org.folio.querytool.domain.dto.DateType;
 import org.folio.querytool.domain.dto.EntityDataType;
 import org.folio.querytool.domain.dto.EntityType;
@@ -32,7 +33,8 @@ class FqlToSqlConverterTest {
           new EntityTypeColumn().name("field1").dataType(new EntityDataType().dataType("stringType")),
           new EntityTypeColumn().name("field2").dataType(new EntityDataType().dataType("stringType")),
           new EntityTypeColumn().name("field3").dataType(new EntityDataType().dataType("stringType")),
-          new EntityTypeColumn().name("field4").dataType(new DateType())
+          new EntityTypeColumn().name("field4").dataType(new DateType()),
+          new EntityTypeColumn().name("arrayField").dataType(new ArrayType())
         )
       );
   }
@@ -253,6 +255,26 @@ class FqlToSqlConverterTest {
     String fqlCondition = """
       {"field1": {"$nin": ["value1", 2, true]}}
       """;
+    Condition actualCondition = fqlToSqlConverter.getSqlCondition(fqlCondition, entityType);
+    assertEquals(expectedCondition, actualCondition);
+  }
+
+  @Test
+  void shouldGetJooqConditionForFqlContainsStringCondition() {
+    String fqlCondition = """
+      {"arrayField": {"$contains": "some value"}}
+      """;
+    Condition expectedCondition = field("arrayField").containsIgnoreCase("some value");
+    Condition actualCondition = fqlToSqlConverter.getSqlCondition(fqlCondition, entityType);
+    assertEquals(expectedCondition, actualCondition);
+  }
+
+  @Test
+  void shouldGetJooqConditionForFqlContainsNumericCondition() {
+    String fqlCondition = """
+      {"arrayField": {"$contains": 10}}
+      """;
+    Condition expectedCondition = field("arrayField").contains(10);
     Condition actualCondition = fqlToSqlConverter.getSqlCondition(fqlCondition, entityType);
     assertEquals(expectedCondition, actualCondition);
   }


### PR DESCRIPTION
## Purpose
[Add CONTAINS operator to handle arrays](https://issues.folio.org/browse/LIBFQMQUER-2)

Add a contains operator to handle array db fields. This operator should return any rows where the array db column contains the user-provided value. Currently, the user-provided value must be a single value (i.e., not an array). For string values, upper/lowercase is ignored. 

## Testing
- [x] All unit tests passed
- [x] Array columns can be queried with the $contains operator (actually also works for non-array fields):
<img width="812" alt="Screenshot 2023-09-18 at 12 34 08 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/1b1baef6-b089-4b12-b04f-569bece98108">

**---------------------------------------------------------------------------------------**

<img width="839" alt="Screenshot 2023-09-18 at 12 34 32 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/4700af6f-d9bf-4e62-bb9e-93058c4ea526">


- [x] Contains operator can be combined with itself and other operators:
<img width="1134" alt="Screenshot 2023-09-18 at 12 41 33 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/31fcfd4e-ccec-465e-b6ba-f7c5759abeb6">

**---------------------------------------------------------------------------------------**

<img width="746" alt="Screenshot 2023-09-18 at 12 41 56 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/e3e4e0f8-b888-4a6e-87c3-8968fd46a124">

