### PR TITLE
LIBFQMQUER-3: Add NOT CONTAINS operator for arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ Example:
 {"field1": {"$nin": ["value1", "value2"]}}
 ```
 
+### $contains
+Matches all records where the field (an array) contains the specified value. Supports string, number, and uuid types.
+
+Example:
+```json
+{"field1": {"$contains": 12}}
+```
+
+### $not_contains
+Matches all records where the field (an array) does not contain the specified value, or is null. Supports string, number, and uuid types.
+
+Example:
+```json
+{"field1": {"$not_contains": "value1"}}
+```
+
 ### $regex
 Provides regular expression capabilities for pattern matching strings in queries. At present, only the following two
 patterns are supported.

--- a/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
+++ b/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
@@ -31,17 +31,18 @@ public class ConditionDeserializer extends StdScalarDeserializer<FqlCondition<?>
     IS_AND, AND_DESERIALIZER
   );
 
-  private static final Map<FieldPredicates, FieldDeserializers> FIELD_DESERIALIZERS = Map.of(
-    IS_EQ, EQ_DESERIALIZER,
-    IS_NE, NE_DESERIALIZER,
-    IS_IN, IN_DESERIALIZER,
-    IS_NIN, NIN_DESERIALIZER,
-    IS_GT, GT_DESERIALIZER,
-    IS_GTE, GTE_DESERIALIZER,
-    IS_LT, LT_DESERIALIZER,
-    IS_LTE, LTE_DESERIALIZER,
-    IS_REGEX, REGEX_DESERIALIZER,
-    IS_CONTAINS, CONTAINS_DESERIALIZER
+  private static final Map<FieldPredicates, FieldDeserializers> FIELD_DESERIALIZERS = Map.ofEntries(
+    Map.entry(IS_EQ, EQ_DESERIALIZER),
+    Map.entry(IS_NE, NE_DESERIALIZER),
+    Map.entry(IS_IN, IN_DESERIALIZER),
+    Map.entry(IS_NIN, NIN_DESERIALIZER),
+    Map.entry(IS_GT, GT_DESERIALIZER),
+    Map.entry(IS_GTE, GTE_DESERIALIZER),
+    Map.entry(IS_LT, LT_DESERIALIZER),
+    Map.entry(IS_LTE, LTE_DESERIALIZER),
+    Map.entry(IS_REGEX, REGEX_DESERIALIZER),
+    Map.entry(IS_CONTAINS, CONTAINS_DESERIALIZER),
+    Map.entry(IS_NOT_CONTAINS, NOT_CONTAINS_DESERIALIZER)
   );
 
   private final ObjectMapper mapper;

--- a/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
+++ b/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
@@ -20,6 +20,7 @@ import static org.folio.fql.model.LessThanCondition.$LT;
 import static org.folio.fql.model.LessThanCondition.$LTE;
 import static org.folio.fql.model.InCondition.$IN;
 import static org.folio.fql.model.NotInCondition.$NIN;
+import static org.folio.fql.model.NotContainsCondition.$NOT_CONTAINS;
 import static org.folio.fql.model.RegexCondition.$REGEX;
 import static org.folio.fql.model.AndCondition.$AND;
 
@@ -34,7 +35,8 @@ public class DeserializerFunctions {
     IS_LT(node -> node.has($LT) && node.get(LessThanCondition.$LT).isValueNode()),
     IS_LTE(node -> node.has($LTE) && node.get($LTE).isValueNode()),
     IS_REGEX(node -> node.has($REGEX) && node.get($REGEX).isTextual()),
-    IS_CONTAINS(node -> node.has($CONTAINS) && node.get($CONTAINS).isValueNode());
+    IS_CONTAINS(node -> node.has($CONTAINS) && node.get($CONTAINS).isValueNode()),
+    IS_NOT_CONTAINS(node -> node.has($NOT_CONTAINS) && node.get($NOT_CONTAINS).isValueNode());
 
     final Predicate<JsonNode> predicate;
 
@@ -63,7 +65,8 @@ public class DeserializerFunctions {
     LT_DESERIALIZER((field, node) -> new LessThanCondition(field, false, convertValue(node.get($LT)))),
     LTE_DESERIALIZER((field, node) -> new LessThanCondition(field, true, convertValue(node.get($LTE)))),
     REGEX_DESERIALIZER((field, node) -> new RegexCondition(field, node.get($REGEX).textValue())),
-    CONTAINS_DESERIALIZER((field, node) -> new ContainsCondition(field, convertValue(node.get($CONTAINS))));
+    CONTAINS_DESERIALIZER((field, node) -> new ContainsCondition(field, convertValue(node.get($CONTAINS)))),
+    NOT_CONTAINS_DESERIALIZER((field, node) -> new NotContainsCondition(field, convertValue(node.get($NOT_CONTAINS))));
 
     final BiFunction<String, JsonNode, FieldCondition<?>> deserializer;
 

--- a/src/main/java/org/folio/fql/model/FieldCondition.java
+++ b/src/main/java/org/folio/fql/model/FieldCondition.java
@@ -1,6 +1,6 @@
 package org.folio.fql.model;
 
 public sealed interface FieldCondition<T> extends FqlCondition<T> permits EqualsCondition, GreaterThanCondition,
-  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition {
+  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition, NotContainsCondition {
   String fieldName();
 }

--- a/src/main/java/org/folio/fql/model/NotContainsCondition.java
+++ b/src/main/java/org/folio/fql/model/NotContainsCondition.java
@@ -1,0 +1,5 @@
+package org.folio.fql.model;
+
+public record NotContainsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+  public static final String $NOT_CONTAINS = "$not_contains";
+}

--- a/src/main/java/org/folio/fqm/lib/repository/FqlToSqlConverter.java
+++ b/src/main/java/org/folio/fqm/lib/repository/FqlToSqlConverter.java
@@ -36,7 +36,8 @@ public class FqlToSqlConverter {
     LessThanCondition.class, (cnd, ent) -> handleLessThan((LessThanCondition) cnd, ent),
     AndCondition.class, (cnd, ent) -> handleAnd((AndCondition) cnd, ent),
     RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd, ent),
-    ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent)
+    ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent),
+    NotContainsCondition.class, (cnd, ent) -> handleNotContains((NotContainsCondition) cnd, ent)
   );
 
   /**
@@ -193,6 +194,14 @@ public class FqlToSqlConverter {
       return field(containsCondition, entityType).containsIgnoreCase(s);
     }
     return field(containsCondition, entityType).contains(containsCondition.value());
+  }
+
+  private Condition handleNotContains(NotContainsCondition notContainsCondition, EntityType entityType) {
+    Field<Object> field = field(notContainsCondition, entityType);
+    if (notContainsCondition.value() instanceof String s) {
+      return field.notContainsIgnoreCase(s).or(field(notContainsCondition, entityType).isNull());
+    }
+    return field.notContains(notContainsCondition.value()).or(field(notContainsCondition, entityType).isNull());
   }
 
   private Field<Object> field(FieldCondition<?> condition, EntityType entityType) {

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotContainsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotContainsTest.java
@@ -1,7 +1,7 @@
 package org.folio.fql.deserializer;
 
 import org.folio.fql.FqlService;
-import org.folio.fql.model.ContainsCondition;
+import org.folio.fql.model.NotContainsCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FqlDeserializerContainsTest {
+public class FqlDeserializerNotContainsTest {
 
   private FqlService fqlService;
 
@@ -21,34 +21,34 @@ public class FqlDeserializerContainsTest {
 
   @Test
   void shouldGetSimpleContainsFqlWithStringValue() {
-    String simpleContainsJson =
+    String simpleNotContainsJson =
       """
-         {"arrayField1": {"$contains": "value"}}
+         {"arrayField1": {"$not_contains": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", "value");
+    FqlCondition<?> fqlCondition = new NotContainsCondition("arrayField1", "value");
     Fql expectedFql = new Fql(fqlCondition);
-    Fql actualFql = fqlService.getFql(simpleContainsJson);
+    Fql actualFql = fqlService.getFql(simpleNotContainsJson);
     assertEquals(expectedFql, actualFql);
   }
 
   @Test
   void shouldGetSimpleContainsFqlWithIntegerValue() {
-    String simpleContainsJson =
+    String simpleNotContainsJson =
       """
-        {"arrayField1": {"$contains": 11}}
+        {"arrayField1": {"$not_contains": 11}}
         """;
-    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", 11);
+    FqlCondition<?> fqlCondition = new NotContainsCondition("arrayField1", 11);
     Fql expectedFql = new Fql(fqlCondition);
-    Fql actualFql = fqlService.getFql(simpleContainsJson);
+    Fql actualFql = fqlService.getFql(simpleNotContainsJson);
     assertEquals(expectedFql, actualFql);
   }
 
   @Test
   void shouldThrowExceptionWhenContainsConditionIsNotValueNode() {
-    String invalidEqualsConditionJson =
+    String invalidNotContainsJson =
       """
-        {"arrayField1": {"$contains": ["value1", "value2", "value3" ] }}
+        {"arrayField1": {"$not_contains": ["value1", "value2", "value3" ] }}
         """;
-    assertThrows(FqlParsingException.class, () -> fqlService.getFql(invalidEqualsConditionJson));
+    assertThrows(FqlParsingException.class, () -> fqlService.getFql(invalidNotContainsJson));
   }
 }

--- a/src/test/java/org/folio/fqm/lib/repository/FqlToSqlConverterTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/FqlToSqlConverterTest.java
@@ -280,6 +280,26 @@ class FqlToSqlConverterTest {
   }
 
   @Test
+  void shouldGetJooqConditionForFqlNotContainsStringCondition() {
+    String fqlCondition = """
+      {"arrayField": {"$not_contains": "some value"}}
+      """;
+    Condition expectedCondition = field("arrayField").notContainsIgnoreCase("some value").or(field("arrayField").isNull());
+    Condition actualCondition = fqlToSqlConverter.getSqlCondition(fqlCondition, entityType);
+    assertEquals(expectedCondition, actualCondition);
+  }
+
+  @Test
+  void shouldGetJooqConditionForFqlNotContainsNumericCondition() {
+    String fqlCondition = """
+      {"arrayField": {"$not_contains": 10}}
+      """;
+    Condition expectedCondition = field("arrayField").notContains(10).or(field("arrayField").isNull());
+    Condition actualCondition = fqlToSqlConverter.getSqlCondition(fqlCondition, entityType);
+    assertEquals(expectedCondition, actualCondition);
+  }
+
+  @Test
   void shouldGetJooqConditionForComplexFql() {
     String complexFql = """
       {


### PR DESCRIPTION
## Purpose
[Add NOT CONTAINS operator to handle arrays](https://issues.folio.org/browse/LIBFQMQUER-3)

Add a notContains operator to handle array db fields. This operator should return any rows where the array db column does not contain the user-provided value, or is null. Currently, the user-provided value must be a single value (i.e., not an array). For string values, upper/lowercase is ignored. 

## Testing
- [x] All unit tests passed
- [x] Array columns can be queried with the $not_contains operator (actually also works for non-array fields):
<img width="851" alt="Screenshot 2023-09-18 at 3 33 07 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/ccc21c86-b54f-48b9-8178-882bfc0d5833">

**------------------------------------------------------------------------------------------**

<img width="990" alt="Screenshot 2023-09-18 at 3 33 36 PM" src="https://github.com/folio-org/lib-fqm-query-processor/assets/97990858/f278ce87-7efe-42d4-9601-c2eb517eea88">
