### PR TITLE
Refactor to sort queries immediately

### DIFF
--- a/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
@@ -76,12 +76,11 @@ public class IdStreamer {
     return streamIdsInBatch(entityType, derivedTable, sortResults, condition, batchSize, idsConsumer);
   }
 
-  public List<UUID> getSortedIds(String tenantId, EntityType entityType,
-                                 Condition sqlWhereClause, int offset, int batchSize) {
+  public List<UUID> getSortedIds(String tenantId,
+                                 int offset, int batchSize) {
     return jooqContext.dsl()
         .select(field("result_id"))
         .from(table(metaDataRepository.getFqmSchemaName(tenantId) + ".query_results"))
-//        .where(sqlWhereClause)
         .orderBy(field("sort_seq"))
         .offset(offset)
         .limit(batchSize)

--- a/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
@@ -77,10 +77,11 @@ public class IdStreamer {
   }
 
   public List<UUID> getSortedIds(String tenantId,
-                                 int offset, int batchSize) {
+                                 UUID queryId, int offset, int batchSize) {
     return jooqContext.dsl()
         .select(field("result_id"))
         .from(table(metaDataRepository.getFqmSchemaName(tenantId) + ".query_results"))
+        .where(field("query_id").eq(queryId))
         .orderBy(field("sort_seq"))
         .offset(offset)
         .limit(batchSize)

--- a/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/lib/repository/IdStreamer.java
@@ -76,13 +76,13 @@ public class IdStreamer {
     return streamIdsInBatch(entityType, derivedTable, sortResults, condition, batchSize, idsConsumer);
   }
 
-  public List<UUID> getSortedIds(String derivedTableName, EntityType entityType,
+  public List<UUID> getSortedIds(String tenantId, EntityType entityType,
                                  Condition sqlWhereClause, int offset, int batchSize) {
     return jooqContext.dsl()
-        .select(field(ID_FIELD_NAME))
-        .from(derivedTableName)
-        .where(sqlWhereClause)
-        .orderBy(getSortFields(entityType, true))
+        .select(field("result_id"))
+        .from(table(metaDataRepository.getFqmSchemaName(tenantId) + ".query_results"))
+//        .where(sqlWhereClause)
+        .orderBy(field("sort_seq"))
         .offset(offset)
         .limit(batchSize)
         .fetchInto(UUID.class);

--- a/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
+++ b/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
@@ -69,12 +69,6 @@ public class QueryResultsSorterService {
   public List<UUID> getSortedIds(String tenantId, UUID queryId,
                                  int offset, int limit) {
     log.debug("Getting sorted ids for query {}, offset {}, limit {}", queryId, offset, limit);
-    return idStreamer.getSortedIds(tenantId, offset, limit);
+    return idStreamer.getSortedIds(tenantId, queryId, offset, limit);
   }
-
-
-  // TODO: remove
-//  private String getFqmSchemaName(String tenantId) {
-//    return tenantId + "_mod_fqm_manager";
-//  }
 }

--- a/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
+++ b/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
@@ -78,7 +78,7 @@ public class QueryResultsSorterService {
         .where(field("query_id").eq(queryId))
     );
     // Sort ids based on the sort criteria defined in the entity type definition
-    return idStreamer.getSortedIds(derivedTableName, entityType, condition, offset, limit);
+    return idStreamer.getSortedIds(tenantId, entityType, condition, offset, limit);
   }
 
   private String getFqmSchemaName(String tenantId) {

--- a/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
+++ b/src/main/java/org/folio/fqm/lib/service/QueryResultsSorterService.java
@@ -4,8 +4,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.lib.model.IdsWithCancelCallback;
 import org.folio.fqm.lib.repository.IdStreamer;
 import org.folio.fqm.lib.repository.MetaDataRepository;
-import org.folio.querytool.domain.dto.EntityType;
-import org.jooq.Condition;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -13,7 +11,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
-import static org.folio.fqm.lib.repository.MetaDataRepository.ID_FIELD_NAME;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.table;
@@ -69,19 +66,15 @@ public class QueryResultsSorterService {
     }
   }
 
-  public List<UUID> getSortedIds(String tenantId, UUID queryId, String derivedTableName,
-                                 EntityType entityType, int offset, int limit) {
+  public List<UUID> getSortedIds(String tenantId, UUID queryId,
+                                 int offset, int limit) {
     log.debug("Getting sorted ids for query {}, offset {}, limit {}", queryId, offset, limit);
-    Condition condition = field(ID_FIELD_NAME).in(
-      select(field("result_id"))
-        .from(table(getFqmSchemaName(tenantId) + ".query_results"))
-        .where(field("query_id").eq(queryId))
-    );
-    // Sort ids based on the sort criteria defined in the entity type definition
-    return idStreamer.getSortedIds(tenantId, entityType, condition, offset, limit);
+    return idStreamer.getSortedIds(tenantId, offset, limit);
   }
 
-  private String getFqmSchemaName(String tenantId) {
-    return tenantId + "_mod_fqm_manager";
-  }
+
+  // TODO: remove
+//  private String getFqmSchemaName(String tenantId) {
+//    return tenantId + "_mod_fqm_manager";
+//  }
 }

--- a/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
@@ -77,7 +77,7 @@ class IdStreamerTest {
         .from(table("Tenant_01_mod_fqm_manager.query_results"))
         .where(field("query_id").eq(queryId))
     );
-    List<UUID> actualIds = idStreamer.getSortedIds(derivedTableName, entityType, condition, offset, limit);
+    List<UUID> actualIds = idStreamer.getSortedIds(derivedTableName, offset, limit);
     assertEquals(IdStreamerTestDataProvider.TEST_CONTENT_IDS, actualIds);
   }
 

--- a/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/lib/repository/IdStreamerTest.java
@@ -67,17 +67,11 @@ class IdStreamerTest {
 
   @Test
   void shouldGetSortedIds() {
+    String tenantId = "tenant_01";
     UUID queryId = UUID.randomUUID();
     int offset = 0;
     int limit = 0;
-    String derivedTableName = "table_01";
-    EntityType entityType = new EntityType().name("test-entity");
-    Condition condition = field(ID_FIELD_NAME).in(
-      select(field("result_id"))
-        .from(table("Tenant_01_mod_fqm_manager.query_results"))
-        .where(field("query_id").eq(queryId))
-    );
-    List<UUID> actualIds = idStreamer.getSortedIds(derivedTableName, offset, limit);
+    List<UUID> actualIds = idStreamer.getSortedIds(tenantId, queryId, offset, limit);
     assertEquals(IdStreamerTestDataProvider.TEST_CONTENT_IDS, actualIds);
   }
 

--- a/src/test/java/org/folio/fqm/lib/repository/dataproviders/IdStreamerTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/lib/repository/dataproviders/IdStreamerTestDataProvider.java
@@ -37,7 +37,7 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
   private static final String DERIVED_TABLE_NAME_QUERY_REGEX = "SELECT DERIVED_TABLE_NAME FROM .*\\.ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String ENTITY_TYPE_DEFINITION_REGEX = "SELECT DEFINITION FROM .*\\.ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String GET_IDS_QUERY_REGEX = "SELECT ID FROM .*_MOD_FQM_MANAGER\\..* WHERE .* ORDER BY ID ASC";
-  private static final String GET_SORTED_IDS_QUERY_REGEX = "SELECT ID FROM .* WHERE ID IN \\(SELECT RESULT_ID FROM .*_MOD_FQM_MANAGER.QUERY_RESULTS WHERE QUERY_ID = .*";
+  private static final String GET_SORTED_IDS_QUERY_REGEX = "SELECT RESULT_ID FROM .* WHERE QUERY_ID = .*";
   private static final String GET_ENTITY_TYPE_ID_FROM_QUERY_ID_REGEX = "SELECT ENTITY_TYPE_ID FROM .*.QUERY_DETAILS WHERE QUERY_ID = .*";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
+++ b/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
@@ -79,8 +79,8 @@ class QueryResultsSorterServiceTest {
         .where(field("query_id").eq(queryId))
     );
     List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
-    when(idStreamer.getSortedIds(derivedTableName, entityType, condition, offset, limit)).thenReturn(expectedIds);
-    List<UUID> actualIds = queryResultsSorterService.getSortedIds(tenantId, queryId, derivedTableName, entityType, offset, limit);
+    when(idStreamer.getSortedIds(derivedTableName, offset, limit)).thenReturn(expectedIds);
+    List<UUID> actualIds = queryResultsSorterService.getSortedIds(tenantId, queryId, offset, limit);
     assertEquals(expectedIds, actualIds);
   }
 }

--- a/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
+++ b/src/test/java/org/folio/fqm/lib/service/QueryResultsSorterServiceTest.java
@@ -71,15 +71,8 @@ class QueryResultsSorterServiceTest {
     UUID queryId = UUID.randomUUID();
     int offset = 0;
     int limit = 0;
-    String derivedTableName = "table_01";
-    EntityType entityType = new EntityType().name("test-entity");
-    Condition condition = field(ID_FIELD_NAME).in(
-      select(field("result_id"))
-        .from(table("tenant_01_mod_fqm_manager.query_results"))
-        .where(field("query_id").eq(queryId))
-    );
     List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
-    when(idStreamer.getSortedIds(derivedTableName, offset, limit)).thenReturn(expectedIds);
+    when(idStreamer.getSortedIds(tenantId, queryId, offset, limit)).thenReturn(expectedIds);
     List<UUID> actualIds = queryResultsSorterService.getSortedIds(tenantId, queryId, offset, limit);
     assertEquals(expectedIds, actualIds);
   }


### PR DESCRIPTION
## Purpose
- Refactoring to do query sorting immediately when a query is posted, rather than during list refresh

## Testing
- [x] All unit tests passed
- [x] Query execution works normally
- [x] List refreshes work normally
- [x] Posting/putting lists works properly