### PR TITLE
[maven-release-plugin] prepare release v1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,2 @@
+## 1.0.0
+* Initial release

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>lib-fqm-query-processor</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>lib-fqm-query-processor</name>
   <description>FQM Query processor library</description>
   <organization>
@@ -29,7 +29,7 @@
     <url>https://github.com/folio-org/lib-fqm-query-processor</url>
     <connection>scm:git:git://github.com/folio-org/lib-fqm-query-processor.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/lib-fqm-query-processor.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>lib-fqm-query-processor</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>lib-fqm-query-processor</name>
   <description>FQM Query processor library</description>
   <organization>
@@ -15,7 +15,7 @@
   <properties>
     <java.version>17</java.version>
     <junit-jupiter-api.version>5.9.3</junit-jupiter-api.version>
-    <folio-query-tool-metadata.version>1.0.0-SNAPSHOT</folio-query-tool-metadata.version>
+    <folio-query-tool-metadata.version>1.0.0</folio-query-tool-metadata.version>
     <mockito-core.version>5.3.0</mockito-core.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>lib-fqm-query-processor</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <name>lib-fqm-query-processor</name>
   <description>FQM Query processor library</description>
   <organization>
@@ -30,7 +29,7 @@
     <url>https://github.com/folio-org/lib-fqm-query-processor</url>
     <connection>scm:git:git://github.com/folio-org/lib-fqm-query-processor.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/lib-fqm-query-processor.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.0.0</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
This commit changes the lib version from 0.0.1 to 1.0.0. It also bumps
the dependency on folio-query-tool-metadata to a non-snapshot version