### PR TITLE
MODFQMMGR-119: Add empty FQL operator

### DIFF
--- a/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
+++ b/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
@@ -42,7 +42,8 @@ public class ConditionDeserializer extends StdScalarDeserializer<FqlCondition<?>
     Map.entry(IS_LTE, LTE_DESERIALIZER),
     Map.entry(IS_REGEX, REGEX_DESERIALIZER),
     Map.entry(IS_CONTAINS, CONTAINS_DESERIALIZER),
-    Map.entry(IS_NOT_CONTAINS, NOT_CONTAINS_DESERIALIZER)
+    Map.entry(IS_NOT_CONTAINS, NOT_CONTAINS_DESERIALIZER),
+    Map.entry(IS_EMPTY, EMPTY_DESERIALIZER)
   );
 
   private final ObjectMapper mapper;

--- a/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
+++ b/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.folio.fql.model.ContainsCondition.$CONTAINS;
+import static org.folio.fql.model.EmptyCondition.$EMPTY;
 import static org.folio.fql.model.EqualsCondition.$EQ;
 import static org.folio.fql.model.NotEqualsCondition.$NE;
 import static org.folio.fql.model.GreaterThanCondition.$GT;
@@ -36,7 +37,8 @@ public class DeserializerFunctions {
     IS_LTE(node -> node.has($LTE) && node.get($LTE).isValueNode()),
     IS_REGEX(node -> node.has($REGEX) && node.get($REGEX).isTextual()),
     IS_CONTAINS(node -> node.has($CONTAINS) && node.get($CONTAINS).isValueNode()),
-    IS_NOT_CONTAINS(node -> node.has($NOT_CONTAINS) && node.get($NOT_CONTAINS).isValueNode());
+    IS_NOT_CONTAINS(node -> node.has($NOT_CONTAINS) && node.get($NOT_CONTAINS).isValueNode()),
+    IS_EMPTY(node -> node.has($EMPTY) && node.get($EMPTY).isBoolean());
 
     final Predicate<JsonNode> predicate;
 
@@ -66,7 +68,8 @@ public class DeserializerFunctions {
     LTE_DESERIALIZER((field, node) -> new LessThanCondition(field, true, convertValue(node.get($LTE)))),
     REGEX_DESERIALIZER((field, node) -> new RegexCondition(field, node.get($REGEX).textValue())),
     CONTAINS_DESERIALIZER((field, node) -> new ContainsCondition(field, convertValue(node.get($CONTAINS)))),
-    NOT_CONTAINS_DESERIALIZER((field, node) -> new NotContainsCondition(field, convertValue(node.get($NOT_CONTAINS))));
+    NOT_CONTAINS_DESERIALIZER((field, node) -> new NotContainsCondition(field, convertValue(node.get($NOT_CONTAINS)))),
+    EMPTY_DESERIALIZER((field, node) -> new EmptyCondition(field, convertValue(node.get($EMPTY))));
 
     final BiFunction<String, JsonNode, FieldCondition<?>> deserializer;
 

--- a/src/main/java/org/folio/fql/model/EmptyCondition.java
+++ b/src/main/java/org/folio/fql/model/EmptyCondition.java
@@ -1,0 +1,5 @@
+package org.folio.fql.model;
+
+public record EmptyCondition(String fieldName, Object value) implements FieldCondition<Object> {
+  public static final String $EMPTY = "$empty";
+}

--- a/src/main/java/org/folio/fql/model/FieldCondition.java
+++ b/src/main/java/org/folio/fql/model/FieldCondition.java
@@ -1,6 +1,7 @@
 package org.folio.fql.model;
 
 public sealed interface FieldCondition<T> extends FqlCondition<T> permits EqualsCondition, GreaterThanCondition,
-  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition, NotContainsCondition {
+  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition, NotContainsCondition,
+  EmptyCondition {
   String fieldName();
 }

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerEmptyTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerEmptyTest.java
@@ -1,0 +1,53 @@
+package org.folio.fql.deserializer;
+
+import org.folio.fql.model.EmptyCondition;
+import org.folio.fql.model.EqualsCondition;
+import org.folio.fql.model.Fql;
+import org.folio.fql.model.FqlCondition;
+import org.folio.fql.service.FqlService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FqlDeserializerEmptyTest {
+
+  private FqlService fqlService;
+
+  @BeforeEach
+  void setup() {
+    fqlService = new FqlService();
+  }
+
+  @Test
+  void shouldGetSimpleEmptyCondition() {
+    String simpleStringJson =
+      """
+         {"field1": {"$empty": true}}
+        """;
+    FqlCondition<?> fqlCondition = new EmptyCondition("field1", true);
+    Fql expectedFql = new Fql(fqlCondition);Fql actualFql = fqlService.getFql(simpleStringJson);
+    assertEquals(expectedFql, actualFql);
+  }
+
+  @Test
+  void shouldGetSimpleNotEmptyCondition() {
+    String simpleStringJson =
+      """
+         {"field1": {"$empty": false}}
+        """;
+    FqlCondition<?> fqlCondition = new EmptyCondition("field1", false);
+    Fql expectedFql = new Fql(fqlCondition);Fql actualFql = fqlService.getFql(simpleStringJson);
+    assertEquals(expectedFql, actualFql);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenEmptyConditionIsNotBoolean() {
+    String invalidEqualsConditionJson =
+      """
+        {"field1": {"$empty": "maybe"}}
+        """;
+    assertThrows(FqlParsingException.class, () -> fqlService.getFql(invalidEqualsConditionJson));
+  }
+}


### PR DESCRIPTION
## Purpose
[MODFQMMGR-119](https://issues.folio.org/browse/MODFQMMGR-119): Create new operators to support searching for null/empty values

## Testing
- [x] All unit tests passed
- [x] Empty operator works for all datatypes