### PR TITLE
[LIBFQMQUER-11] Define and implement nested object/array field syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ mvn clean install
 ## FQL Language Syntax
 FQL uses a light version of MongoDB query syntax. The supported operators are described below.
 
+### Field names
+
+Field names can represent a column itself (most typical), or a nested JSON object/array.
+For example, the following field names are valid:
+
+- `field1`: represents a column named `field1`
+- `field2->inner`: represents the property named `field2` nested within a column named `field2`
+- `field3[*]->inner`: represents the property named `field2` nested within any item of the column `field3`
+
+For these examples, example contents of each field could be:
+
+- `field1`: `value1`, `value2`, `value3`, `[0, 2, 4, 7]`, `["foo", "bar", "baz"]`
+- `field2`: `{"inner": "value1"}`, `{"inner": "value2"}`, `{"inner": "value3"}`
+- `field3`: `[{"inner": "value1"}, {"inner": "value2"}, {"inner": "value3"}]`, `[]`
+
+Note that arrays containing primitive types (not objects) should **not** be queried using this syntax; instead, they should
+be queried using the `$contains` and `$not_contains` array operators.
+
+A formal definition of the FQL field name is below:
+
+```
+field_name  ::= column_name |
+                column_name '->' field_name |
+                column_name '[*]' '->' field_name
+column_name ::= [a-zA-Z_][a-zA-Z0-9_]*
+```
+
 ### $eq
 Match values that are equal to a specified value. String comparison is done in a case-insensitive manner. Supports
 string, number, boolean, date and uuid types.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A formal definition of the FQL field name is below:
 ```
 field_name  ::= column_name |
                 column_name '->' field_name |
-                column_name '[*]' '->' field_name
+                column_name '[*]'* '->' field_name
 column_name ::= [a-zA-Z_][a-zA-Z0-9_]*
 ```
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
+++ b/src/main/java/org/folio/fql/deserializer/ConditionDeserializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.FieldCondition;
 import org.folio.fql.model.LogicalCondition;
+import org.folio.fql.model.field.FqlField;
 
 import java.io.IOException;
 import java.util.Map;
@@ -65,7 +66,8 @@ public class ConditionDeserializer extends StdScalarDeserializer<FqlCondition<?>
     }
 
     if (isFieldCondition(childNode)) {
-      return getFieldCondition(fieldName, childNode);
+      FqlField field = new FqlField(fieldName);
+      return getFieldCondition(field, childNode);
     }
 
     throw new FqlParsingException(fieldName, String.format(INVALID_OPERATOR_MESSAGE, childNode.toString()));
@@ -93,13 +95,13 @@ public class ConditionDeserializer extends StdScalarDeserializer<FqlCondition<?>
       .orElseThrow(() -> new FqlParsingException(fieldName, String.format(INVALID_OPERATOR_MESSAGE, node.toString())));
   }
 
-  private FieldCondition<?> getFieldCondition(String fieldName, JsonNode node) {
+  private FieldCondition<?> getFieldCondition(FqlField field, JsonNode node) {
     return FIELD_DESERIALIZERS.keySet()
       .stream()
       .filter(p -> p.predicate.test(node))
       .map(FIELD_DESERIALIZERS::get)
-      .map(d -> d.deserializer.apply(fieldName, node))
+      .map(d -> d.deserializer.apply(field, node))
       .findFirst()
-      .orElseThrow(() -> new FqlParsingException(fieldName, String.format(INVALID_OPERATOR_MESSAGE, node.toString())));
+      .orElseThrow(() -> new FqlParsingException(field.serialize(), String.format(INVALID_OPERATOR_MESSAGE, node.toString())));
   }
 }

--- a/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
+++ b/src/main/java/org/folio/fql/deserializer/DeserializerFunctions.java
@@ -2,7 +2,22 @@ package org.folio.fql.deserializer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.folio.fql.model.*;
+
+import org.folio.fql.model.AndCondition;
+import org.folio.fql.model.ContainsCondition;
+import org.folio.fql.model.EmptyCondition;
+import org.folio.fql.model.EqualsCondition;
+import org.folio.fql.model.FieldCondition;
+import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.GreaterThanCondition;
+import org.folio.fql.model.InCondition;
+import org.folio.fql.model.LessThanCondition;
+import org.folio.fql.model.LogicalCondition;
+import org.folio.fql.model.NotContainsCondition;
+import org.folio.fql.model.NotEqualsCondition;
+import org.folio.fql.model.NotInCondition;
+import org.folio.fql.model.RegexCondition;
+import org.folio.fql.model.field.FqlField;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -71,9 +86,9 @@ public class DeserializerFunctions {
     NOT_CONTAINS_DESERIALIZER((field, node) -> new NotContainsCondition(field, convertValue(node.get($NOT_CONTAINS)))),
     EMPTY_DESERIALIZER((field, node) -> new EmptyCondition(field, convertValue(node.get($EMPTY))));
 
-    final BiFunction<String, JsonNode, FieldCondition<?>> deserializer;
+    final BiFunction<FqlField, JsonNode, FieldCondition<?>> deserializer;
 
-    FieldDeserializers(BiFunction<String, JsonNode, FieldCondition<?>> deserializer) {
+    FieldDeserializers(BiFunction<FqlField, JsonNode, FieldCondition<?>> deserializer) {
       this.deserializer = deserializer;
     }
 

--- a/src/main/java/org/folio/fql/model/ContainsCondition.java
+++ b/src/main/java/org/folio/fql/model/ContainsCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record ContainsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record ContainsCondition(FqlField field, Object value) implements FieldCondition<Object> {
   public static final String $CONTAINS = "$contains";
 }

--- a/src/main/java/org/folio/fql/model/EmptyCondition.java
+++ b/src/main/java/org/folio/fql/model/EmptyCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record EmptyCondition(String fieldName, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record EmptyCondition(FqlField field, Object value) implements FieldCondition<Object> {
   public static final String $EMPTY = "$empty";
 }

--- a/src/main/java/org/folio/fql/model/EqualsCondition.java
+++ b/src/main/java/org/folio/fql/model/EqualsCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record EqualsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record EqualsCondition(FqlField field, Object value) implements FieldCondition<Object> {
   public static final String $EQ = "$eq";
 }

--- a/src/main/java/org/folio/fql/model/FieldCondition.java
+++ b/src/main/java/org/folio/fql/model/FieldCondition.java
@@ -1,7 +1,19 @@
 package org.folio.fql.model;
 
-public sealed interface FieldCondition<T> extends FqlCondition<T> permits EqualsCondition, GreaterThanCondition,
-  InCondition, LessThanCondition, NotEqualsCondition, NotInCondition, RegexCondition, ContainsCondition, NotContainsCondition,
-  EmptyCondition {
-  String fieldName();
+import org.folio.fql.model.field.FqlField;
+
+public sealed interface FieldCondition<T>
+  extends FqlCondition<T>
+  permits
+    EqualsCondition,
+    GreaterThanCondition,
+    InCondition,
+    LessThanCondition,
+    NotEqualsCondition,
+    NotInCondition,
+    RegexCondition,
+    ContainsCondition,
+    NotContainsCondition,
+    EmptyCondition {
+  FqlField field();
 }

--- a/src/main/java/org/folio/fql/model/GreaterThanCondition.java
+++ b/src/main/java/org/folio/fql/model/GreaterThanCondition.java
@@ -1,6 +1,8 @@
 package org.folio.fql.model;
 
-public record GreaterThanCondition(String fieldName, boolean orEqualTo,
+import org.folio.fql.model.field.FqlField;
+
+public record GreaterThanCondition(FqlField field, boolean orEqualTo,
                                    Object value) implements FieldCondition<Object> {
   public static final String $GT = "$gt";
   public static final String $GTE = "$gte";

--- a/src/main/java/org/folio/fql/model/InCondition.java
+++ b/src/main/java/org/folio/fql/model/InCondition.java
@@ -1,7 +1,8 @@
 package org.folio.fql.model;
 
 import java.util.List;
+import org.folio.fql.model.field.FqlField;
 
-public record InCondition(String fieldName, List<Object> value) implements FieldCondition<List<Object>> {
+public record InCondition(FqlField field, List<Object> value) implements FieldCondition<List<Object>> {
   public static final String $IN = "$in";
 }

--- a/src/main/java/org/folio/fql/model/LessThanCondition.java
+++ b/src/main/java/org/folio/fql/model/LessThanCondition.java
@@ -1,6 +1,8 @@
 package org.folio.fql.model;
 
-public record LessThanCondition(String fieldName, boolean orEqualTo, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record LessThanCondition(FqlField field, boolean orEqualTo, Object value) implements FieldCondition<Object> {
   public static final String $LT = "$lt";
   public static final String $LTE = "$lte";
 }

--- a/src/main/java/org/folio/fql/model/NotContainsCondition.java
+++ b/src/main/java/org/folio/fql/model/NotContainsCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record NotContainsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record NotContainsCondition(FqlField field, Object value) implements FieldCondition<Object> {
   public static final String $NOT_CONTAINS = "$not_contains";
 }

--- a/src/main/java/org/folio/fql/model/NotEqualsCondition.java
+++ b/src/main/java/org/folio/fql/model/NotEqualsCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record NotEqualsCondition(String fieldName, Object value) implements FieldCondition<Object> {
+import org.folio.fql.model.field.FqlField;
+
+public record NotEqualsCondition(FqlField field, Object value) implements FieldCondition<Object> {
   public static final String $NE = "$ne";
 }

--- a/src/main/java/org/folio/fql/model/NotInCondition.java
+++ b/src/main/java/org/folio/fql/model/NotInCondition.java
@@ -1,7 +1,8 @@
 package org.folio.fql.model;
 
 import java.util.List;
+import org.folio.fql.model.field.FqlField;
 
-public record NotInCondition(String fieldName, List<Object> value) implements FieldCondition<List<Object>> {
+public record NotInCondition(FqlField field, List<Object> value) implements FieldCondition<List<Object>> {
   public static final String $NIN = "$nin";
 }

--- a/src/main/java/org/folio/fql/model/RegexCondition.java
+++ b/src/main/java/org/folio/fql/model/RegexCondition.java
@@ -1,5 +1,7 @@
 package org.folio.fql.model;
 
-public record RegexCondition(String fieldName, String value) implements FieldCondition<String> {
+import org.folio.fql.model.field.FqlField;
+
+public record RegexCondition(FqlField field, String value) implements FieldCondition<String> {
   public static final String $REGEX = "$regex";
 }

--- a/src/main/java/org/folio/fql/model/field/ArraySubField.java
+++ b/src/main/java/org/folio/fql/model/field/ArraySubField.java
@@ -1,0 +1,8 @@
+package org.folio.fql.model.field;
+
+public record ArraySubField() implements SubField {
+  @Override
+  public String serialize() {
+    return "[*]";
+  }
+}

--- a/src/main/java/org/folio/fql/model/field/FqlField.java
+++ b/src/main/java/org/folio/fql/model/field/FqlField.java
@@ -1,11 +1,10 @@
 package org.folio.fql.model.field;
 
-import org.folio.fql.deserializer.FqlParsingException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Value;
+import org.folio.fql.deserializer.FqlParsingException;
 
 @Value
 public class FqlField {
@@ -26,6 +25,7 @@ public class FqlField {
     }
   }
 
+  /** Finds the first [*] or -> in the string; if none, it returns -1 */
   private static int getIndexOfSubfield(String str) {
     int firstArrayIndex = str.indexOf("[*]");
     int firstPropertyIndex = str.indexOf("->");

--- a/src/main/java/org/folio/fql/model/field/FqlField.java
+++ b/src/main/java/org/folio/fql/model/field/FqlField.java
@@ -1,0 +1,71 @@
+package org.folio.fql.model.field;
+
+import org.folio.fql.deserializer.FqlParsingException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Value;
+
+@Value
+public class FqlField {
+
+  private final String columnName;
+  private final List<SubField> subFields;
+
+  public FqlField(String field) {
+    int firstSubFieldIndex = getIndexOfSubfield(field);
+
+    this.subFields = new ArrayList<>();
+
+    if (firstSubFieldIndex == -1) {
+      this.columnName = field;
+    } else {
+      this.columnName = field.substring(0, firstSubFieldIndex);
+      parseSubFields(field, field.substring(firstSubFieldIndex));
+    }
+  }
+
+  private static int getIndexOfSubfield(String str) {
+    int firstArrayIndex = str.indexOf("[*]");
+    int firstPropertyIndex = str.indexOf("->");
+
+    int firstSubFieldIndex = Math.min(firstArrayIndex, firstPropertyIndex);
+    // if one of the indexes is -1 (nonexistent), then we always use the other one
+    // if both are -1 (no subfields), this will keep -1
+    if (firstSubFieldIndex == -1) {
+      firstSubFieldIndex = Math.max(firstArrayIndex, firstPropertyIndex);
+    }
+
+    return firstSubFieldIndex;
+  }
+
+  private void parseSubFields(String field, String substring) {
+    if (substring.startsWith("->")) {
+      String remaining = substring.substring(2);
+      int nestedIndex = getIndexOfSubfield(remaining);
+      if (nestedIndex == -1) {
+        subFields.add(new PropertySubField(remaining));
+      } else {
+        subFields.add(new PropertySubField(remaining.substring(0, nestedIndex)));
+        parseSubFields(field, remaining.substring(nestedIndex));
+      }
+    } else if (substring.startsWith("[*]")) {
+      String remaining = substring.substring(3);
+      int nestedIndex = getIndexOfSubfield(remaining);
+      if (nestedIndex == -1) {
+        throw new FqlParsingException(field, "Array subfields [*] must be followed by a property subfield");
+      } else {
+        subFields.add(new ArraySubField());
+        parseSubFields(field, remaining.substring(nestedIndex));
+      }
+    } else {
+      throw new IllegalArgumentException("Unrecognized subfield did not start with -> or [*]: " + substring);
+    }
+  }
+
+  /** Get the field name as the String that would be used in the FQL query */
+  public String serialize() {
+    return columnName + subFields.stream().map(SubField::serialize).collect(Collectors.joining());
+  }
+}

--- a/src/main/java/org/folio/fql/model/field/PropertySubField.java
+++ b/src/main/java/org/folio/fql/model/field/PropertySubField.java
@@ -1,0 +1,8 @@
+package org.folio.fql.model.field;
+
+public record PropertySubField(String propertyName) implements SubField {
+  @Override
+  public String serialize() {
+    return "->" + propertyName;
+  }
+}

--- a/src/main/java/org/folio/fql/model/field/SubField.java
+++ b/src/main/java/org/folio/fql/model/field/SubField.java
@@ -1,0 +1,6 @@
+package org.folio.fql.model.field;
+
+public sealed interface SubField permits ArraySubField, PropertySubField {
+  /** Get the field name as the String that would be used in the FQL query */
+  public String serialize();
+}

--- a/src/main/java/org/folio/fql/service/FqlService.java
+++ b/src/main/java/org/folio/fql/service/FqlService.java
@@ -3,7 +3,6 @@ package org.folio.fql.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import java.util.ArrayList;
 import java.util.List;
 import org.folio.fql.deserializer.ConditionDeserializer;
 import org.folio.fql.deserializer.FqlDeserializer;
@@ -12,6 +11,7 @@ import org.folio.fql.model.AndCondition;
 import org.folio.fql.model.FieldCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.field.FqlField;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -33,17 +33,17 @@ public class FqlService {
     }
   }
 
-  public List<String> getFqlFields(Fql fql) {
+  public List<FqlField> getFqlFields(Fql fql) {
     FqlCondition<?> fqlCondition = fql.fqlCondition();
+
     if (fqlCondition instanceof AndCondition andCondition) {
-      List<String> fields = new ArrayList<>();
-      andCondition
+      return andCondition
         .value()
-        .forEach(cnd -> fields.add(((FieldCondition<?>) cnd).fieldName()));
-      return fields;
+        .stream().map(cnd -> ((FieldCondition<?>) cnd).field()).toList();
     }
+
     FieldCondition<?> fieldCondition = (FieldCondition<?>) fqlCondition;
-    return List.of(fieldCondition.fieldName());
+    return List.of(fieldCondition.field());
   }
 
   private static ObjectMapper getMapper() {

--- a/src/main/java/org/folio/fql/service/FqlValidationService.java
+++ b/src/main/java/org/folio/fql/service/FqlValidationService.java
@@ -1,13 +1,26 @@
 package org.folio.fql.service;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+
 import org.folio.fql.deserializer.FqlParsingException;
 import org.folio.fql.model.AndCondition;
 import org.folio.fql.model.FieldCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.field.ArraySubField;
+import org.folio.fql.model.field.FqlField;
+import org.folio.fql.model.field.PropertySubField;
+import org.folio.fql.model.field.SubField;
+import org.folio.querytool.domain.dto.ArrayType;
+import org.folio.querytool.domain.dto.EntityDataType;
 import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.folio.querytool.domain.dto.NestedObjectProperty;
+import org.folio.querytool.domain.dto.ObjectType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -21,10 +34,7 @@ public class FqlValidationService {
     this.fqlService = fqlService;
   }
 
-  public Map<String, String> validateFql(
-    EntityType entityType,
-    String fqlCriteria
-  ) {
+  public Map<String, String> validateFql(EntityType entityType, String fqlCriteria) {
     try {
       Fql fql = fqlService.getFql(fqlCriteria);
       FqlCondition<?> fqlCondition = fql.fqlCondition();
@@ -34,41 +44,67 @@ public class FqlValidationService {
     }
   }
 
-  private Map<String, String> assertFqlFieldPresentInEntityType(
-    FqlCondition<?> fqlCondition,
-    EntityType entityType
-  ) {
+  private Map<String, String> assertFqlFieldPresentInEntityType(FqlCondition<?> fqlCondition, EntityType entityType) {
     Map<String, String> errorMap = new HashMap<>();
     if (fqlCondition instanceof AndCondition andCondition) {
       andCondition
         .value()
-        .forEach(subCondition ->
-          errorMap.putAll(
-            assertFqlFieldPresentInEntityType(subCondition, entityType)
-          )
-        );
+        .forEach(subCondition -> errorMap.putAll(assertFqlFieldPresentInEntityType(subCondition, entityType)));
     } else {
+      FqlField field = ((FieldCondition<?>) fqlCondition).field();
+
       entityType
         .getColumns()
         .stream()
-        .filter(col ->
-          col.getName().equals(((FieldCondition<?>) fqlCondition).fieldName())
-        )
+        .filter(col -> checkColumnMatch(field, col))
         .findFirst()
         .ifPresentOrElse(
           value -> {},
           () -> {
-            String fieldName = ((FieldCondition<?>) fqlCondition).fieldName();
+            String fieldName = field.serialize();
             errorMap.put(
               fieldName,
-              "Field " +
-              fieldName +
-              " is not present in definition of entity type " +
-              entityType.getName()
+              "Field " + fieldName + " is not present in definition of entity type " + entityType.getName()
             );
           }
         );
     }
     return errorMap;
+  }
+
+  public static boolean checkColumnMatch(FqlField field, EntityTypeColumn col) {
+    if (!col.getName().equals(field.getColumnName())) {
+      return false;
+    }
+
+    Deque<SubField> subFields = new ArrayDeque<>(field.getSubFields());
+    EntityDataType dataType = col.getDataType();
+
+    while (!subFields.isEmpty()) {
+      SubField subField = subFields.pop();
+      if (subField instanceof ArraySubField) {
+        if (dataType instanceof ArrayType arrayDataType) {
+          dataType = arrayDataType.getItemDataType();
+        } else {
+          return false;
+        }
+      } else if (subField instanceof PropertySubField propertySubField) {
+        if (dataType instanceof ObjectType objectDataType) {
+          Optional<NestedObjectProperty> nestedProperty = objectDataType.getProperties().stream()
+            .filter(subCol -> subCol.getName().equals(propertySubField.propertyName()))
+            .findFirst();
+
+          if (nestedProperty.isPresent()) {
+            dataType = nestedProperty.get().getDataType();
+          } else {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 }

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerContainsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerContainsTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.ContainsCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FqlDeserializerContainsTest {
+class FqlDeserializerContainsTest {
 
   private FqlService fqlService;
 
@@ -25,7 +26,7 @@ public class FqlDeserializerContainsTest {
       """
          {"arrayField1": {"$contains": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", "value");
+    FqlCondition<?> fqlCondition = new ContainsCondition(new FqlField("arrayField1"), "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleContainsJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ public class FqlDeserializerContainsTest {
       """
         {"arrayField1": {"$contains": 11}}
         """;
-    FqlCondition<?> fqlCondition = new ContainsCondition("arrayField1", 11);
+    FqlCondition<?> fqlCondition = new ContainsCondition(new FqlField("arrayField1"), 11);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleContainsJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerEmptyTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerEmptyTest.java
@@ -1,9 +1,9 @@
 package org.folio.fql.deserializer;
 
 import org.folio.fql.model.EmptyCondition;
-import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class FqlDeserializerEmptyTest {
       """
          {"field1": {"$empty": true}}
         """;
-    FqlCondition<?> fqlCondition = new EmptyCondition("field1", true);
+    FqlCondition<?> fqlCondition = new EmptyCondition(new FqlField("field1"), true);
     Fql expectedFql = new Fql(fqlCondition);Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
   }
@@ -37,7 +37,7 @@ class FqlDeserializerEmptyTest {
       """
          {"field1": {"$empty": false}}
         """;
-    FqlCondition<?> fqlCondition = new EmptyCondition("field1", false);
+    FqlCondition<?> fqlCondition = new EmptyCondition(new FqlField("field1"), false);
     Fql expectedFql = new Fql(fqlCondition);Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
   }

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerEqualsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerEqualsTest.java
@@ -2,6 +2,7 @@ package org.folio.fql.deserializer;
 
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,7 @@ class FqlDeserializerEqualsTest {
       """
          {"field1": {"$eq": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new EqualsCondition("field1", "value");
+    FqlCondition<?> fqlCondition = new EqualsCondition(new FqlField("field1"), "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ class FqlDeserializerEqualsTest {
       """
         {"field1": {"$eq": true}}
         """;
-    FqlCondition<?> fqlCondition = new EqualsCondition("field1", true);
+    FqlCondition<?> fqlCondition = new EqualsCondition(new FqlField("field1"), true);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleBooleanJson);
     assertEquals(expectedFql, actualFql);
@@ -49,7 +50,7 @@ class FqlDeserializerEqualsTest {
       """
         {"field1": {"$eq": 11}}
         """;
-    FqlCondition<?> fqlCondition = new EqualsCondition("field1", 11);
+    FqlCondition<?> fqlCondition = new EqualsCondition(new FqlField("field1"), 11);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleIntegerJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerGreaterThanTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerGreaterThanTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.GreaterThanCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class FqlDeserializerGreaterThanTest {
       """
          {"field1": {"$gt": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new GreaterThanCondition("field1", false, "value");
+    FqlCondition<?> fqlCondition = new GreaterThanCondition(new FqlField("field1"), false, "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ class FqlDeserializerGreaterThanTest {
       """
          {"field1": {"$gte": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new GreaterThanCondition("field1", true, "value");
+    FqlCondition<?> fqlCondition = new GreaterThanCondition(new FqlField("field1"), true, "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -67,7 +68,7 @@ class FqlDeserializerGreaterThanTest {
       """
          {"field1": {"$gt": 10}}
         """;
-    FqlCondition<?> fqlCondition = new GreaterThanCondition("field1", false, 10);
+    FqlCondition<?> fqlCondition = new GreaterThanCondition(new FqlField("field1"), false, 10);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -79,7 +80,7 @@ class FqlDeserializerGreaterThanTest {
       """
          {"field1": {"$gte": 10}}
         """;
-    FqlCondition<?> fqlCondition = new GreaterThanCondition("field1", true, 10);
+    FqlCondition<?> fqlCondition = new GreaterThanCondition(new FqlField("field1"), true, 10);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerInTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerInTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.InCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class FqlDeserializerInTest {
       """
         {"field1": {"$in": ["value1", 11, false ] }}
         """;
-    FqlCondition<?> fqlCondition = new InCondition("field1", List.of("value1", 11, false));
+    FqlCondition<?> fqlCondition = new InCondition(new FqlField("field1"), List.of("value1", 11, false));
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleInConditionJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerLessThanTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerLessThanTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.LessThanCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class FqlDeserializerLessThanTest {
       """
          {"field1": {"$lt": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new LessThanCondition("field1", false, "value");
+    FqlCondition<?> fqlCondition = new LessThanCondition(new FqlField("field1"), false, "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ class FqlDeserializerLessThanTest {
       """
          {"field1": {"$lte": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new LessThanCondition("field1", true, "value");
+    FqlCondition<?> fqlCondition = new LessThanCondition(new FqlField("field1"), true, "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -67,7 +68,7 @@ class FqlDeserializerLessThanTest {
       """
          {"field1": {"$lt": 10}}
         """;
-    FqlCondition<?> fqlCondition = new LessThanCondition("field1", false, 10);
+    FqlCondition<?> fqlCondition = new LessThanCondition(new FqlField("field1"), false, 10);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -79,7 +80,7 @@ class FqlDeserializerLessThanTest {
       """
          {"field1": {"$lte": 10}}
         """;
-    FqlCondition<?> fqlCondition = new LessThanCondition("field1", true, 10);
+    FqlCondition<?> fqlCondition = new LessThanCondition(new FqlField("field1"), true, 10);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotContainsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotContainsTest.java
@@ -1,6 +1,7 @@
 package org.folio.fql.deserializer;
 
 import org.folio.fql.model.NotContainsCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.service.FqlService;
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FqlDeserializerNotContainsTest {
+class FqlDeserializerNotContainsTest {
 
   private FqlService fqlService;
 
@@ -25,7 +26,7 @@ public class FqlDeserializerNotContainsTest {
       """
          {"arrayField1": {"$not_contains": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new NotContainsCondition("arrayField1", "value");
+    FqlCondition<?> fqlCondition = new NotContainsCondition(new FqlField("arrayField1"), "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleNotContainsJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ public class FqlDeserializerNotContainsTest {
       """
         {"arrayField1": {"$not_contains": 11}}
         """;
-    FqlCondition<?> fqlCondition = new NotContainsCondition("arrayField1", 11);
+    FqlCondition<?> fqlCondition = new NotContainsCondition(new FqlField("arrayField1"), 11);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleNotContainsJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotEqualsTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotEqualsTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.NotEqualsCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class FqlDeserializerNotEqualsTest {
       """
          {"field1": {"$ne": "value"}}
         """;
-    FqlCondition<?> fqlCondition = new NotEqualsCondition("field1", "value");
+    FqlCondition<?> fqlCondition = new NotEqualsCondition(new FqlField("field1"), "value");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);
@@ -37,7 +38,7 @@ class FqlDeserializerNotEqualsTest {
       """
         {"field1": {"$ne": true}}
         """;
-    FqlCondition<?> fqlCondition = new NotEqualsCondition("field1", true);
+    FqlCondition<?> fqlCondition = new NotEqualsCondition(new FqlField("field1"), true);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleBooleanJson);
     assertEquals(expectedFql, actualFql);
@@ -49,7 +50,7 @@ class FqlDeserializerNotEqualsTest {
       """
         {"field1": {"$ne": 11}}
         """;
-    FqlCondition<?> fqlCondition = new NotEqualsCondition("field1", 11);
+    FqlCondition<?> fqlCondition = new NotEqualsCondition(new FqlField("field1"), 11);
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleIntegerJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotInTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerNotInTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.NotInCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class FqlDeserializerNotInTest {
       """
         {"field1": {"$nin": ["value1", 11, false ] }}
         """;
-    FqlCondition<?> fqlCondition = new NotInCondition("field1", List.of("value1", 11, false));
+    FqlCondition<?> fqlCondition = new NotInCondition(new FqlField("field1"), List.of("value1", 11, false));
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleNotInConditionJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerRegExTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerRegExTest.java
@@ -3,6 +3,7 @@ package org.folio.fql.deserializer;
 import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.RegexCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class FqlDeserializerRegExTest {
       """
          {"field1": {"$regex": ".*value.*"}}
         """;
-    FqlCondition<?> fqlCondition = new RegexCondition("field1", ".*value.*");
+    FqlCondition<?> fqlCondition = new RegexCondition(new FqlField("field1"), ".*value.*");
     Fql expectedFql = new Fql(fqlCondition);
     Fql actualFql = fqlService.getFql(simpleStringJson);
     assertEquals(expectedFql, actualFql);

--- a/src/test/java/org/folio/fql/deserializer/FqlDeserializerTest.java
+++ b/src/test/java/org/folio/fql/deserializer/FqlDeserializerTest.java
@@ -4,6 +4,7 @@ import org.folio.fql.model.Fql;
 import org.folio.fql.model.FqlCondition;
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.InCondition;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.model.AndCondition;
 import org.folio.fql.service.FqlService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,21 +38,23 @@ class FqlDeserializerTest {
                                 {"field4" : {"$eq": false}}
                             ]
                        },
-                       {"field5" : {"$in": ["value1", 2, false]}}
+                       {"field5" : {"$in": ["value1", 2, false]}},
+                       {"field6->nested" : {"$eq": "nested value"}}
                ]
             }
         """;
     List<Object> inValues = List.of("value1", 2, false);
     List<FqlCondition<?>> innerFqlConditions = List.of(
-      new EqualsCondition("field3", "another value"),
-      new EqualsCondition("field4", false)
+      new EqualsCondition(new FqlField("field3"), "another value"),
+      new EqualsCondition(new FqlField("field4"), false)
     );
     AndCondition innerAndCondition = new AndCondition(innerFqlConditions);
     List<FqlCondition<?>> outerFqlConditions = List.of(
-      new EqualsCondition("field1", "some value"),
-      new EqualsCondition("field2", 2),
+      new EqualsCondition(new FqlField("field1"), "some value"),
+      new EqualsCondition(new FqlField("field2"), 2),
       innerAndCondition,
-      new InCondition("field5", inValues)
+      new InCondition(new FqlField("field5"), inValues),
+      new EqualsCondition(new FqlField("field6->nested"), "nested value")
     );
     AndCondition outerAndCondition = new AndCondition(outerFqlConditions);
     Fql expectedFql = new Fql(outerAndCondition);

--- a/src/test/java/org/folio/fql/service/FqlServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlServiceTest.java
@@ -1,14 +1,15 @@
 package org.folio.fql.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
 import org.folio.fql.model.*;
+import org.folio.fql.model.field.FqlField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 class FqlServiceTest {
+
   private FqlService fqlService;
 
   @BeforeEach
@@ -18,23 +19,25 @@ class FqlServiceTest {
 
   @Test
   void shouldReturnFieldsForValidFqlFieldCondition() {
-    EqualsCondition equalsCondition = new EqualsCondition("field1", "value1");
+    EqualsCondition equalsCondition = new EqualsCondition(new FqlField("field1->nested"), "value1");
     Fql fql = new Fql(equalsCondition);
-    List<String> expectedList = List.of("field1");
-    List<String> actualList = fqlService.getFqlFields(fql);
+    List<String> expectedList = List.of("field1->nested");
+    List<String> actualList = fqlService.getFqlFields(fql).stream().map(FqlField::serialize).toList();
     assertEquals(expectedList, actualList);
   }
 
   @Test
   void shouldReturnFieldsForValidFqlAndCondition() {
-    AndCondition andCondition = new AndCondition(List.of(
-      new EqualsCondition("field1", "value1"),
-      new NotEqualsCondition("field2", "value2"),
-      new GreaterThanCondition("field3", false, 10)
-    ));
+    AndCondition andCondition = new AndCondition(
+      List.of(
+        new EqualsCondition(new FqlField("field1"), "value1"),
+        new NotEqualsCondition(new FqlField("field2"), "value2"),
+        new GreaterThanCondition(new FqlField("field3"), false, 10)
+      )
+    );
     Fql fql = new Fql(andCondition);
     List<String> expectedList = List.of("field1", "field2", "field3");
-    List<String> actualList = fqlService.getFqlFields(fql);
+    List<String> actualList = fqlService.getFqlFields(fql).stream().map(FqlField::serialize).toList();
     assertEquals(expectedList, actualList);
   }
 }

--- a/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
@@ -153,6 +153,9 @@ class FqlValidationServiceTest {
   static List<Arguments> nestedFieldValidityParameters() {
     return List.of(
       Arguments.of("foo->bar", false),
+      Arguments.of("field1->foo", false),
+      Arguments.of("field1[*]", false),
+      Arguments.of("field1[*]->foo", false),
       Arguments.of("objectField", true),
       Arguments.of("objectField->property1", true),
       Arguments.of("objectField->property1->foo", false),

--- a/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
@@ -6,11 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
+import org.folio.querytool.domain.dto.ArrayType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.folio.querytool.domain.dto.NestedObjectProperty;
+import org.folio.querytool.domain.dto.ObjectType;
 import org.folio.querytool.domain.dto.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class FqlValidationServiceTest {
 
@@ -20,7 +26,33 @@ class FqlValidationServiceTest {
       List.of(
         new EntityTypeColumn().name("field1").dataType(new StringType()),
         new EntityTypeColumn().name("field2").dataType(new StringType()),
-        new EntityTypeColumn().name("field3").dataType(new StringType())
+        new EntityTypeColumn().name("field3").dataType(new StringType()),
+        new EntityTypeColumn().name("objectField").dataType(new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))),
+        new EntityTypeColumn().name("objectObjectField").dataType(
+          new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1").dataType(
+            new ObjectType().addPropertiesItem(new NestedObjectProperty().name("innerProperty1"))
+          ))
+        ),
+        new EntityTypeColumn().name("objectObjectObjectField").dataType(
+          new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1").dataType(
+            new ObjectType().addPropertiesItem(new NestedObjectProperty().name("innerProperty1").dataType(
+              new ObjectType().addPropertiesItem(new NestedObjectProperty().name("innerInnerProperty1"))
+            ))
+          ))
+        ),
+        new EntityTypeColumn().name("arrayField").dataType(new ArrayType().itemDataType(new StringType())),
+        new EntityTypeColumn().name("arrayObjectField").dataType(
+          new ArrayType().itemDataType(
+            new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))
+          )
+        ),
+        new EntityTypeColumn().name("arrayArrayObjectField").dataType(
+          new ArrayType().itemDataType(
+            new ArrayType().itemDataType(
+              new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))
+            )
+          )
+        )
       )
     );
 
@@ -116,5 +148,55 @@ class FqlValidationServiceTest {
     );
     Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, fqlCondition);
     assertEquals(expectedErrors, actualErrors);
+  }
+
+  static List<Arguments> nestedFieldValidityParameters() {
+    return List.of(
+      Arguments.of("foo->bar", false),
+      Arguments.of("objectField", true),
+      Arguments.of("objectField->property1", true),
+      Arguments.of("objectField->property1->foo", false),
+      Arguments.of("objectField->property1[*]", false),
+      Arguments.of("objectField->property2", false),
+      Arguments.of("objectField[*]", false),
+      Arguments.of("objectObjectField", true),
+      Arguments.of("objectObjectField->property1", true),
+      Arguments.of("objectObjectField->property1->innerProperty1", true),
+      Arguments.of("objectObjectField->property1->innerProperty1->foo", false),
+      Arguments.of("objectObjectField->property1->innerProperty1[*]", false),
+      Arguments.of("objectObjectField->property1[*]", false),
+      Arguments.of("objectObjectField->property2", false),
+      Arguments.of("objectObjectField->property1->foo", false),
+      Arguments.of("objectObjectObjectField", true),
+      Arguments.of("objectObjectObjectField->property1", true),
+      Arguments.of("objectObjectObjectField->property1->innerProperty1", true),
+      Arguments.of("objectObjectObjectField->property1->innerProperty1->innerInnerProperty1", true),
+      Arguments.of("objectObjectObjectField->property1->innerProperty1->innerInnerProperty1->foo", false),
+      Arguments.of("objectObjectObjectField->property1->innerProperty1->foo", false),
+      Arguments.of("arrayField", true),
+      Arguments.of("arrayField->foo", false),
+      Arguments.of("arrayField[*]", false), // disallowed to have [*] with no property
+      Arguments.of("arrayField[*]->foo", false),
+      Arguments.of("arrayObjectField", true),
+      Arguments.of("arrayObjectField->property1", false),
+      Arguments.of("arrayObjectField[*]", false), // disallowed to have [*] with no property
+      Arguments.of("arrayObjectField[*]->property1", true),
+      Arguments.of("arrayObjectField[*]->property1->foo", false),
+      Arguments.of("arrayObjectField[*]->property2", false),
+      Arguments.of("arrayArrayObjectField", true),
+      Arguments.of("arrayArrayObjectField->property1", false),
+      Arguments.of("arrayArrayObjectField[*]", false), // disallowed to have [*] with no property
+      Arguments.of("arrayArrayObjectField[*][*]", false), // disallowed to have [*] with no property
+      Arguments.of("arrayArrayObjectField[*][*]->property1", true),
+      Arguments.of("arrayArrayObjectField[*][*]->property1->foo", false),
+      Arguments.of("arrayArrayObjectField[*][*]->property2", false)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("nestedFieldValidityParameters")
+  void testNestedFieldValidity(String fieldName, boolean expectedValidity) {
+    Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, "{ \"%s\": { \"$eq\": true } }".formatted(fieldName));
+    assertEquals(expectedValidity, actualErrors.isEmpty());
   }
 }


### PR DESCRIPTION
# [Jira LIBFQMQUER-11](https://folio-org.atlassian.net/browse/LIBFQMQUER-11)

## Purpose

This PR defines and implements a new, richer field specification which allows defining nested properties/arrays rather than simple column names.

## Approach

The `String fieldName` property in conditions was replaced with a more extensible `FqlField field`, which handles parsing the new syntax (e.g. `field->property`, `field[*]->property->foo`).  Most of the new logic is there (for parsing) and in `FqlValidationService` (to ensure that nested property names exist inside the entity type).