### PR TITLE
 [LIBFQMQUER-12] Resolve fields with idColumnName to the original column

### DIFF
--- a/src/main/java/org/folio/fql/service/FqlValidationService.java
+++ b/src/main/java/org/folio/fql/service/FqlValidationService.java
@@ -109,9 +109,13 @@ public class FqlValidationService {
       }
     }
 
-    return Optional.of(curField).map(field -> {
+    return Optional.of(curField);
+  }
+
+  public static Optional<Field> findFieldDefinitionForQuerying(FqlField search, EntityType entityType) {
+    return findFieldDefinition(search, entityType).map(field -> {
       if (field.getIdColumnName() != null) {
-        return findFieldDefinition(new FqlField(field.getIdColumnName()), entityType).orElse(null);
+        return findFieldDefinitionForQuerying(new FqlField(field.getIdColumnName()), entityType).orElse(null);
       } else {
         return field;
       }

--- a/src/main/java/org/folio/fql/service/FqlValidationService.java
+++ b/src/main/java/org/folio/fql/service/FqlValidationService.java
@@ -109,6 +109,12 @@ public class FqlValidationService {
       }
     }
 
-    return Optional.of(curField);
+    return Optional.of(curField).map(field -> {
+      if (field.getIdColumnName() != null) {
+        return findFieldDefinition(new FqlField(field.getIdColumnName()), entityType).orElse(null);
+      } else {
+        return field;
+      }
+    });
   }
 }

--- a/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
+import org.folio.fql.model.field.FqlField;
 import org.folio.querytool.domain.dto.ArrayType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
@@ -27,7 +28,12 @@ class FqlValidationServiceTest {
         new EntityTypeColumn().name("field1").dataType(new StringType()),
         new EntityTypeColumn().name("field2").dataType(new StringType()),
         new EntityTypeColumn().name("field3").dataType(new StringType()),
-        new EntityTypeColumn().name("objectField").dataType(new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))),
+        new EntityTypeColumn().name("objectField").dataType(
+          new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))
+            .addPropertiesItem(new NestedObjectProperty().name("hasValidIdColumn").idColumnName("field1"))
+            .addPropertiesItem(new NestedObjectProperty().name("hasInvalidIdColumn").idColumnName("does-not-exist"))
+            .addPropertiesItem(new NestedObjectProperty().name("hasNestedIdColumn").idColumnName("objectField->property1"))
+        ),
         new EntityTypeColumn().name("objectObjectField").dataType(
           new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1").dataType(
             new ObjectType().addPropertiesItem(new NestedObjectProperty().name("innerProperty1"))
@@ -52,7 +58,9 @@ class FqlValidationServiceTest {
               new ObjectType().addPropertiesItem(new NestedObjectProperty().name("property1"))
             )
           )
-        )
+        ),
+        new EntityTypeColumn().name("hasValidIdColumn").dataType(new StringType()).idColumnName("field1"),
+        new EntityTypeColumn().name("hasInvalidIdColumn").dataType(new StringType()).idColumnName("does-not-exist")
       )
     );
 
@@ -201,5 +209,35 @@ class FqlValidationServiceTest {
   void testNestedFieldValidity(String fieldName, boolean expectedValidity) {
     Map<String, String> actualErrors = fqlValidationService.validateFql(entityType, "{ \"%s\": { \"$eq\": true } }".formatted(fieldName));
     assertEquals(expectedValidity, actualErrors.isEmpty());
+  }
+
+  static List<Arguments> idColumnResolutionParameters() {
+    return List.of(
+      Arguments.of("hasValidIdColumn", "field1"),
+      Arguments.of("objectField->hasValidIdColumn", "field1"),
+      Arguments.of("objectField->hasNestedIdColumn", "objectField->property1")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("idColumnResolutionParameters")
+  void testIdColumnResolution(String search, String expectedResolution) {
+    assertEquals(
+      FqlValidationService.findFieldDefinition(new FqlField(expectedResolution), entityType).get(),
+      FqlValidationService.findFieldDefinition(new FqlField(search), entityType).get()
+    );
+  }
+
+  static List<Arguments> idColumnResolutionNonexistentParameters() {
+    return List.of(
+      Arguments.of("hasInvalidIdColumn"),
+      Arguments.of("objectField->hasInvalidIdColumn")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("idColumnResolutionNonexistentParameters")
+  void testIdColumnResolutionNonexistent(String search) {
+    assertTrue(FqlValidationService.findFieldDefinition(new FqlField(search), entityType).isEmpty());
   }
 }

--- a/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
@@ -224,7 +224,7 @@ class FqlValidationServiceTest {
   void testIdColumnResolution(String search, String expectedResolution) {
     assertEquals(
       FqlValidationService.findFieldDefinition(new FqlField(expectedResolution), entityType).get(),
-      FqlValidationService.findFieldDefinition(new FqlField(search), entityType).get()
+      FqlValidationService.findFieldDefinitionForQuerying(new FqlField(search), entityType).get()
     );
   }
 
@@ -238,6 +238,6 @@ class FqlValidationServiceTest {
   @ParameterizedTest
   @MethodSource("idColumnResolutionNonexistentParameters")
   void testIdColumnResolutionNonexistent(String search) {
-    assertTrue(FqlValidationService.findFieldDefinition(new FqlField(search), entityType).isEmpty());
+    assertTrue(FqlValidationService.findFieldDefinitionForQuerying(new FqlField(search), entityType).isEmpty());
   }
 }


### PR DESCRIPTION
# [Jira LIBFQMQUER-12](https://folio-org.atlassian.net/browse/LIBFQMQUER-12)

This adds a utility method to resolve columns with an `idColumnName` to the base column they refer to, e.g. will change `vendor_code` and `vendor_name` to `vendor_id`.

This is done as a new method, rather than adding to the existing `findFieldDefinition`, as most of the time we want to refer to the original `Field` (for values, etc.) — the only exception is querying.