### PR TITLE
[LIBFQMQUER-20] part 2: Support MARC tag querying in composite ETs

### DIFF
--- a/src/main/java/org/folio/fql/model/field/MarcFieldName.java
+++ b/src/main/java/org/folio/fql/model/field/MarcFieldName.java
@@ -14,7 +14,10 @@ package org.folio.fql.model.field;
  *   <li>constrained-subfield: {@code indicatorNumber} + {@code indicatorValue} (fixed) + {@code subfield}</li>
  * </ul>
  *
- * @param fieldName       the original field name as referenced in the query (name preserved verbatim)
+ * @param fieldName       the original field name as referenced in the query (name preserved verbatim,
+ *                        including any composite source-alias prefix such as {@code marc_bib.})
+ * @param source          the composite source-alias prefix (e.g. {@code marc_bib}), or null for a
+ *                        non-composite (simple) entity type where the field is un-prefixed
  * @param tag             the three-digit MARC tag
  * @param subfield        the subfield code (lower-cased), or null when not targeting a subfield
  * @param indicatorNumber "1" or "2" when an indicator is involved, otherwise null
@@ -23,6 +26,7 @@ package org.folio.fql.model.field;
  */
 public record MarcFieldName(
   String fieldName,
+  String source,
   String tag,
   String subfield,
   String indicatorNumber,
@@ -33,6 +37,16 @@ public record MarcFieldName(
   public static final String BLANK_INDICATOR_TOKEN = "blank";
   /** How a blank indicator is stored in the MARC indexers table. */
   public static final String BLANK_INDICATOR_STORAGE = "#";
+  private static final String PLACEHOLDER_COLUMN = "marc";
+
+  /**
+   * Name of the generic MARC placeholder column this field correlates against: {@code marc} on a simple entity
+   * type, or {@code <source>.marc} on a composite (where {@code source} may itself be a chain of aliases, e.g.
+   * {@code a.b.marc} for a composite of a composite).
+   */
+  public String placeholderName() {
+    return source == null ? PLACEHOLDER_COLUMN : source + "." + PLACEHOLDER_COLUMN;
+  }
 
   /**
    * True only for the indicator-only form, where the query targets the indicator itself. When a fixed

--- a/src/main/java/org/folio/fql/service/MarcFieldFactory.java
+++ b/src/main/java/org/folio/fql/service/MarcFieldFactory.java
@@ -35,6 +35,9 @@ public class MarcFieldFactory {
    */
   public static final String GENERIC_MARC_COLUMN_NAME = "marc";
 
+  // Suffix a composite's source-prefixed placeholder ends with, e.g. "marc_bib.marc" (chains too: "a.b.marc").
+  private static final String SOURCE_PLACEHOLDER_SUFFIX = "." + GENERIC_MARC_COLUMN_NAME;
+
   // Tag-only form (e.g. marc_245). Matches any subfield of the tag, and is the only valid form for control
   // fields. All patterns match case-insensitively (MARC_245 behaves the same as marc_245).
   private static final Pattern TAG_PATTERN =
@@ -57,7 +60,8 @@ public class MarcFieldFactory {
 
   // Generic scanner for JSON field-name keys in a raw FQL query. It intentionally does NOT encode the MARC
   // grammar. Every candidate key is validated through parse()/isMarcFieldName, so the grammar lives in one place.
-  private static final Pattern QUERY_FIELD_KEY_PATTERN = Pattern.compile("\"(?<field>\\w+)\"\\s*:");
+  // The class allows dots so composite-prefixed keys (marc_bib.marc_245_a) are captured whole, not truncated.
+  private static final Pattern QUERY_FIELD_KEY_PATTERN = Pattern.compile("\"(?<field>[\\w.]+)\"\\s*:");
 
   public static boolean isMarcFieldName(String fieldName) {
     return parse(fieldName).isPresent();
@@ -69,12 +73,24 @@ public class MarcFieldFactory {
       return Optional.empty();
     }
 
+    // On composite entity types the field carries a source-alias prefix (marc_bib.marc_245_a), possibly a chain
+    // (a.b.marc_245_a). The marc_* core never contains a dot, so the last dot is always the source/core boundary;
+    // split there with a plain string op (no regex backtracking). The shape patterns below validate the core.
+    String source = null;
+    String core = fieldName;
+    int lastDot = fieldName.lastIndexOf('.');
+    if (lastDot > 0) {
+      source = fieldName.substring(0, lastDot);
+      core = fieldName.substring(lastDot + 1);
+    }
+
     // Control fields (001-009) have no subfields or indicators, so only the tag-only form is valid for them.
-    Matcher subfieldMatcher = SUBFIELD_PATTERN.matcher(fieldName);
+    Matcher subfieldMatcher = SUBFIELD_PATTERN.matcher(core);
     if (subfieldMatcher.matches() && !isControlFieldTag(subfieldMatcher.group("tag"))) {
       // Preserve the original field name; normalize the subfield code to lower case to match storage.
       return Optional.of(new MarcFieldName(
         fieldName,
+        source,
         subfieldMatcher.group("tag"),
         subfieldMatcher.group("subfield").toLowerCase(),
         null,
@@ -82,10 +98,11 @@ public class MarcFieldFactory {
       ));
     }
 
-    Matcher constrainedMatcher = CONSTRAINED_SUBFIELD_PATTERN.matcher(fieldName);
+    Matcher constrainedMatcher = CONSTRAINED_SUBFIELD_PATTERN.matcher(core);
     if (constrainedMatcher.matches() && !isControlFieldTag(constrainedMatcher.group("tag"))) {
       return Optional.of(new MarcFieldName(
         fieldName,
+        source,
         constrainedMatcher.group("tag"),
         constrainedMatcher.group("subfield").toLowerCase(),
         constrainedMatcher.group("indicator"),
@@ -93,10 +110,11 @@ public class MarcFieldFactory {
       ));
     }
 
-    Matcher indicatorMatcher = INDICATOR_PATTERN.matcher(fieldName);
+    Matcher indicatorMatcher = INDICATOR_PATTERN.matcher(core);
     if (indicatorMatcher.matches() && !isControlFieldTag(indicatorMatcher.group("tag"))) {
       return Optional.of(new MarcFieldName(
         fieldName,
+        source,
         indicatorMatcher.group("tag"),
         null,
         indicatorMatcher.group("indicator"),
@@ -104,9 +122,9 @@ public class MarcFieldFactory {
       ));
     }
 
-    Matcher tagMatcher = TAG_PATTERN.matcher(fieldName);
+    Matcher tagMatcher = TAG_PATTERN.matcher(core);
     if (tagMatcher.matches()) {
-      return Optional.of(new MarcFieldName(fieldName, tagMatcher.group("tag"), null, null, null));
+      return Optional.of(new MarcFieldName(fieldName, source, tagMatcher.group("tag"), null, null, null));
     }
 
     return Optional.empty();
@@ -152,11 +170,27 @@ public class MarcFieldFactory {
       .findFirst();
   }
 
-  /** Whether the column is the generic {@code marc} capability placeholder (see {@link #GENERIC_MARC_COLUMN_NAME}). */
+  /**
+   * The specific MARC placeholder a parsed field correlates against, matched by name
+   * ({@link MarcFieldName#placeholderName()} — {@code marc}, or {@code <source>.marc} on a composite). A composite
+   * may declare more than one MARC source, so the field's own prefix selects the right one.
+   */
+  public static Optional<EntityTypeColumn> findMarcPlaceholder(EntityType entityType, MarcFieldName marcField) {
+    if (entityType == null || entityType.getColumns() == null || marcField == null) {
+      return Optional.empty();
+    }
+    String placeholderName = marcField.placeholderName();
+    return entityType.getColumns().stream()
+      .filter(column -> column.getDataType() instanceof MarcType && placeholderName.equals(column.getName()))
+      .findFirst();
+  }
+
   public static boolean isGenericMarcPlaceholder(EntityTypeColumn column) {
-    return column != null
-      && GENERIC_MARC_COLUMN_NAME.equals(column.getName())
-      && column.getDataType() instanceof MarcType;
+    if (column == null || !(column.getDataType() instanceof MarcType)) {
+      return false;
+    }
+    String name = column.getName();
+    return GENERIC_MARC_COLUMN_NAME.equals(name) || name.endsWith(SOURCE_PLACEHOLDER_SUFFIX);
   }
 
   /**
@@ -180,8 +214,7 @@ public class MarcFieldFactory {
    * entity type is not mutated. The synthesized columns carry no SQL — see {@link #toColumn(MarcFieldName)}.
    */
   public static EntityType addSyntheticColumns(EntityType entityType, Collection<String> fieldNames) {
-    if (fieldNames == null || fieldNames.isEmpty()
-      || entityType == null || entityType.getColumns() == null
+    if (fieldNames == null || fieldNames.isEmpty() || entityType == null || entityType.getColumns() == null
       || findMarcPlaceholder(entityType).isEmpty()) {
       return entityType;
     }
@@ -195,10 +228,14 @@ public class MarcFieldFactory {
       if (fieldName == null || existingFieldNames.contains(fieldName)) {
         continue;
       }
-      parse(fieldName).map(MarcFieldFactory::toColumn).ifPresent(column -> {
-        updatedColumns.add(column);
-        existingFieldNames.add(fieldName);
-      });
+      // Synthesize only when the name parses AND the source's placeholder is present (so a composite correlates
+      // against the right source). Non-MARC names, and fields whose placeholder is absent, are skipped.
+      parse(fieldName)
+        .filter(field -> findMarcPlaceholder(entityType, field).isPresent())
+        .ifPresent(field -> {
+          updatedColumns.add(toColumn(field));
+          existingFieldNames.add(fieldName);
+        });
     }
 
     return entityType.toBuilder().columns(updatedColumns).build();
@@ -210,10 +247,11 @@ public class MarcFieldFactory {
    * support keep rejecting {@code marc_*} references.
    */
   public static Optional<Field> resolveMarcField(String fieldName, EntityType entityType) {
-    if (findMarcPlaceholder(entityType).isEmpty()) {
+    Optional<MarcFieldName> parsed = parse(fieldName);
+    if (parsed.isEmpty() || findMarcPlaceholder(entityType, parsed.get()).isEmpty()) {
       return Optional.empty();
     }
-    return parse(fieldName).<Field>map(MarcFieldFactory::toColumn);
+    return Optional.<Field>of(toColumn(parsed.get()));
   }
 
   // MARC control fields are tags 001-009 (the only valid tags starting with "00"); they have no indicators or

--- a/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
+++ b/src/test/java/org/folio/fql/service/FqlValidationServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class FqlValidationServiceTest {
 
@@ -76,6 +77,27 @@ class FqlValidationServiceTest {
         ),
         new EntityTypeColumn().name("hasValidIdColumn").dataType(new StringType()).idColumnName("field1"),
         new EntityTypeColumn().name("hasInvalidIdColumn").dataType(new StringType()).idColumnName("does-not-exist")
+      )
+    );
+
+  // Entity type that supports dynamic MARC fields, signalled by the hidden generic "marc" placeholder.
+  private static final EntityType marcEntityType = new EntityType()
+    .name("marc_entity_type")
+    .columns(
+      List.of(
+        new EntityTypeColumn().name("field1").dataType(new StringType()),
+        new EntityTypeColumn().name("marc").dataType(new MarcType().dataType("marcType"))
+      )
+    );
+
+  // Composite entity type whose source columns (including the marc placeholders) carry a source-alias prefix.
+  private static final EntityType compositeMarcEntityType = new EntityType()
+    .name("composite_marc_entity_type")
+    .columns(
+      List.of(
+        new EntityTypeColumn().name("marc_bib.external_hrid").dataType(new StringType()),
+        new EntityTypeColumn().name("marc_bib.marc").dataType(new MarcType().dataType("marcType")),
+        new EntityTypeColumn().name("marc_authority.marc").dataType(new MarcType().dataType("marcType"))
       )
     );
 
@@ -273,16 +295,6 @@ class FqlValidationServiceTest {
     assertTrue(FqlValidationService.findFieldDefinitionForQuerying(new FqlField(search), entityType).isEmpty());
   }
 
-  // Entity type that supports dynamic MARC fields, signalled by the hidden generic "marc" placeholder.
-  private static final EntityType marcEntityType = new EntityType()
-    .name("marc_entity_type")
-    .columns(
-      List.of(
-        new EntityTypeColumn().name("field1").dataType(new StringType()),
-        new EntityTypeColumn().name("marc").dataType(new MarcType().dataType("marcType"))
-      )
-    );
-
   static List<String> validMarcFieldNames() {
     return List.of(
       "marc_245",              // tag-only (data field)
@@ -330,6 +342,29 @@ class FqlValidationServiceTest {
   void shouldRejectMalformedMarcFieldEvenWithPlaceholder(String fieldName) {
     Map<String, String> actualErrors =
       fqlValidationService.validateFql(marcEntityType, "{ \"%s\": { \"$eq\": \"x\" } }".formatted(fieldName));
+    assertEquals(1, actualErrors.size());
+    assertTrue(actualErrors.containsKey(fieldName));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "marc_bib.marc_245",
+    "marc_bib.marc_245_a",
+    "marc_bib.marc_245_ind1_7_a",
+    "marc_authority.marc_100_a"
+  })
+  void shouldValidateSourcePrefixedMarcFieldAgainstItsSource(String fieldName) {
+    Map<String, String> actualErrors =
+      fqlValidationService.validateFql(compositeMarcEntityType, "{ \"%s\": { \"$eq\": \"x\" } }".formatted(fieldName));
+    assertEquals(Map.of(), actualErrors);
+  }
+
+  @Test
+  void shouldRejectSourcePrefixedMarcFieldWhenSourceHasNoPlaceholder() {
+    // Valid MARC shape, but marc_holdings is not a declared MARC source on this composite.
+    String fieldName = "marc_holdings.marc_245_a";
+    Map<String, String> actualErrors =
+      fqlValidationService.validateFql(compositeMarcEntityType, "{ \"%s\": { \"$eq\": \"x\" } }".formatted(fieldName));
     assertEquals(1, actualErrors.size());
     assertTrue(actualErrors.containsKey(fieldName));
   }

--- a/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
+++ b/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
@@ -38,7 +38,6 @@ class MarcFieldFactoryTest {
       .columns(List.of(new EntityTypeColumn().name("field1").dataType(new StringType())));
   }
 
-  // Composite entity type: source columns (including the marc placeholder) carry a source-alias prefix.
   private static EntityType compositeEntityType() {
     return new EntityType()
       .name("composite_entity_type")
@@ -242,7 +241,7 @@ class MarcFieldFactoryTest {
       new EntityTypeColumn().name("a.b.marc").dataType(new MarcType().dataType("marcType"))));
     // A prefixed non-placeholder column is not the placeholder.
     assertFalse(MarcFieldFactory.isGenericMarcPlaceholder(
-      new EntityTypeColumn().name("marc_bib.marc_245_a").dataType(new MarcType().dataType("marcType"))));
+      new EntityTypeColumn().name("marc_bib.not_marc").dataType(new MarcType().dataType("marcType"))));
   }
 
   @Test

--- a/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
+++ b/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
@@ -38,6 +38,26 @@ class MarcFieldFactoryTest {
       .columns(List.of(new EntityTypeColumn().name("field1").dataType(new StringType())));
   }
 
+  // Composite entity type: source columns (including the marc placeholder) carry a source-alias prefix.
+  private static EntityType compositeEntityType() {
+    return new EntityType()
+      .name("composite_entity_type")
+      .columns(List.of(
+        new EntityTypeColumn().name("marc_bib.field1").dataType(new StringType()),
+        new EntityTypeColumn().name("marc_bib.marc").dataType(new MarcType().dataType("marcType"))
+      ));
+  }
+
+  // Composite declaring two MARC sources; the field's own prefix must select the matching placeholder.
+  private static EntityType multiSourceCompositeEntityType() {
+    return new EntityType()
+      .name("multi_source_composite")
+      .columns(List.of(
+        new EntityTypeColumn().name("marc_bib.marc").dataType(new MarcType().dataType("marcType")),
+        new EntityTypeColumn().name("marc_authority.marc").dataType(new MarcType().dataType("marcType"))
+      ));
+  }
+
   @ParameterizedTest
   @CsvSource({
     // fieldName,             tag, subfield, indNumber, indValue, labelAlias
@@ -60,6 +80,33 @@ class MarcFieldFactoryTest {
     assertEquals(emptyToNull(indNumber), parsed.indicatorNumber());
     assertEquals(emptyToNull(indValue), parsed.indicatorValue());
     assertEquals(labelAlias, parsed.labelAlias());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    // fieldName,                     source,          tag, subfield, placeholderName
+    "marc_bib.marc_245,               marc_bib,        245, ,         marc_bib.marc",
+    "marc_bib.marc_245_a,             marc_bib,        245, a,        marc_bib.marc",
+    "marc_authority.marc_245_a,       marc_authority,  245, a,        marc_authority.marc",
+    "MARC_BIB.MARC_245_A,             MARC_BIB,        245, a,        MARC_BIB.marc",
+    "a.b.marc_245_a,                  a.b,             245, a,        a.b.marc"
+  })
+  void shouldParseSourcePrefixedForms(String fieldName, String source, String tag, String subfield,
+                                      String placeholderName) {
+    MarcFieldName parsed = MarcFieldFactory.parse(fieldName).orElseThrow();
+    // The original name is preserved verbatim (prefix included), while source/tag/subfield are split out.
+    assertEquals(fieldName, parsed.fieldName());
+    assertEquals(source, parsed.source());
+    assertEquals(tag, parsed.tag());
+    assertEquals(emptyToNull(subfield), parsed.subfield());
+    assertEquals(placeholderName, parsed.placeholderName());
+  }
+
+  @Test
+  void shouldParseUnprefixedFieldWithNullSource() {
+    MarcFieldName parsed = MarcFieldFactory.parse("marc_245_a").orElseThrow();
+    assertNull(parsed.source());
+    assertEquals("marc", parsed.placeholderName());
   }
 
   @ParameterizedTest
@@ -187,6 +234,64 @@ class MarcFieldFactoryTest {
   }
 
   @Test
+  void isGenericMarcPlaceholderAcceptsSourcePrefixedName() {
+    // Composite placeholder: <source>.marc with a chain is also accepted.
+    assertTrue(MarcFieldFactory.isGenericMarcPlaceholder(
+      new EntityTypeColumn().name("marc_bib.marc").dataType(new MarcType().dataType("marcType"))));
+    assertTrue(MarcFieldFactory.isGenericMarcPlaceholder(
+      new EntityTypeColumn().name("a.b.marc").dataType(new MarcType().dataType("marcType"))));
+    // A prefixed non-placeholder column is not the placeholder.
+    assertFalse(MarcFieldFactory.isGenericMarcPlaceholder(
+      new EntityTypeColumn().name("marc_bib.marc_245_a").dataType(new MarcType().dataType("marcType"))));
+  }
+
+  @Test
+  void findMarcPlaceholderByFieldSelectsMatchingSource() {
+    EntityType composite = multiSourceCompositeEntityType();
+
+    MarcFieldName bibField = MarcFieldFactory.parse("marc_bib.marc_245_a").orElseThrow();
+    assertEquals("marc_bib.marc",
+      MarcFieldFactory.findMarcPlaceholder(composite, bibField).orElseThrow().getName());
+
+    MarcFieldName authorityField = MarcFieldFactory.parse("marc_authority.marc_100_a").orElseThrow();
+    assertEquals("marc_authority.marc",
+      MarcFieldFactory.findMarcPlaceholder(composite, authorityField).orElseThrow().getName());
+
+    // A field whose source has no matching placeholder resolves to nothing.
+    MarcFieldName unknownSource = MarcFieldFactory.parse("marc_holdings.marc_245_a").orElseThrow();
+    assertTrue(MarcFieldFactory.findMarcPlaceholder(composite, unknownSource).isEmpty());
+  }
+
+  @Test
+  void findMarcPlaceholderByFieldReturnsEmptyForNullArgs() {
+    MarcFieldName field = MarcFieldFactory.parse("marc_245_a").orElseThrow();
+    assertTrue(MarcFieldFactory.findMarcPlaceholder(null, field).isEmpty());
+    assertTrue(MarcFieldFactory.findMarcPlaceholder(marcEntityType(), null).isEmpty());
+  }
+
+  @Test
+  void resolveMarcFieldResolvesSourcePrefixedField() {
+    Optional<Field> resolved = MarcFieldFactory.resolveMarcField("marc_bib.marc_245_a", compositeEntityType());
+    assertTrue(resolved.isPresent());
+    // The synthetic column keeps the fully-qualified (prefixed) name.
+    assertEquals("marc_bib.marc_245_a", ((EntityTypeColumn) resolved.get()).getName());
+
+    // A valid MARC shape but a source the composite doesn't declare is not resolvable.
+    assertTrue(MarcFieldFactory.resolveMarcField("marc_authority.marc_245_a", compositeEntityType()).isEmpty());
+  }
+
+  @Test
+  void addSyntheticColumnsAppendsSourcePrefixedColumns() {
+    EntityType result = MarcFieldFactory.addSyntheticColumns(
+      multiSourceCompositeEntityType(),
+      Arrays.asList("marc_bib.marc_245_a", "marc_authority.marc_100_a", "marc_holdings.marc_245_a", "marc_245_a"));
+
+    // Both declared sources are synthesized; the undeclared source and the un-prefixed name are skipped.
+    assertEquals(List.of("marc_bib.marc", "marc_authority.marc", "marc_bib.marc_245_a", "marc_authority.marc_100_a"),
+      result.getColumns().stream().map(EntityTypeColumn::getName).toList());
+  }
+
+  @Test
   void getReferencedMarcFieldNamesScansRawQueryKeys() {
     String rawQuery = """
       {
@@ -198,6 +303,22 @@ class MarcFieldFactoryTest {
       }
       """;
     assertEquals(List.of("marc_245_a", "marc_008"),
+      List.copyOf(MarcFieldFactory.getReferencedMarcFieldNames(rawQuery)));
+  }
+
+  @Test
+  void getReferencedMarcFieldNamesScansSourcePrefixedRawQueryKeys() {
+    String rawQuery = """
+      {
+        "$and": [
+          { "marc_bib.marc_245_a": { "$eq": "x" } },
+          { "marc_bib.external_hrid": { "$eq": "y" } },
+          { "marc_authority.marc_100": { "$empty": false } }
+        ]
+      }
+      """;
+    // Prefixed MARC keys are captured whole (not truncated at the dot); the non-MARC prefixed key is excluded.
+    assertEquals(List.of("marc_bib.marc_245_a", "marc_authority.marc_100"),
       List.copyOf(MarcFieldFactory.getReferencedMarcFieldNames(rawQuery)));
   }
 


### PR DESCRIPTION
## Purpose
[LIBFQMQUER-20](https://folio-org.atlassian.net/browse/LIBFQMQUER-20) part 2: Support MARC tag querying in composite ETs