### PR TITLE
[LIBFQMQUER-21] Support indicator-constrained MARC field queries without a subfield

### DIFF
--- a/src/main/java/org/folio/fql/model/field/MarcFieldName.java
+++ b/src/main/java/org/folio/fql/model/field/MarcFieldName.java
@@ -21,9 +21,11 @@ package org.folio.fql.model.field;
  *       {@code ind2Value} + {@code subfield}</li>
  *   <li>indicator target with the other constrained ({@code marc_245_ind1_1_ind2} /
  *       {@code marc_245_ind2_1_ind1}): one indicator value + {@code targetIndicator} = the other indicator</li>
- *   <li>constrained field, no subfield ({@code marc_245_ind1_0}): one or both of {@code ind1Value}/{@code
- *       ind2Value} with no {@code subfield} and no {@code targetIndicator} — the whole field value narrowed to
- *       occurrences whose indicator(s) match (e.g. "field 245 exists with ind1 = 0")</li>
+ *   <li>constrained field, one indicator ({@code marc_245_ind1_0}): one of {@code ind1Value}/{@code ind2Value},
+ *       no {@code subfield} and no {@code targetIndicator} — the whole field value narrowed to occurrences whose
+ *       indicator matches (e.g. "field 245 exists with ind1 = 0")</li>
+ *   <li>constrained field, both indicators ({@code marc_245_ind1_1_ind2_2}): {@code ind1Value} +
+ *       {@code ind2Value}, no {@code subfield} and no {@code targetIndicator}</li>
  * </ul>
  *
  * @param fieldName       the original field name as referenced in the query (name preserved verbatim,

--- a/src/main/java/org/folio/fql/model/field/MarcFieldName.java
+++ b/src/main/java/org/folio/fql/model/field/MarcFieldName.java
@@ -21,6 +21,9 @@ package org.folio.fql.model.field;
  *       {@code ind2Value} + {@code subfield}</li>
  *   <li>indicator target with the other constrained ({@code marc_245_ind1_1_ind2} /
  *       {@code marc_245_ind2_1_ind1}): one indicator value + {@code targetIndicator} = the other indicator</li>
+ *   <li>constrained field, no subfield ({@code marc_245_ind1_0}): one or both of {@code ind1Value}/{@code
+ *       ind2Value} with no {@code subfield} and no {@code targetIndicator} — the whole field value narrowed to
+ *       occurrences whose indicator(s) match (e.g. "field 245 exists with ind1 = 0")</li>
  * </ul>
  *
  * @param fieldName       the original field name as referenced in the query (name preserved verbatim,

--- a/src/main/java/org/folio/fql/service/MarcFieldFactory.java
+++ b/src/main/java/org/folio/fql/service/MarcFieldFactory.java
@@ -73,6 +73,19 @@ public class MarcFieldFactory {
     "^marc_(?<tag>\\d{3})_ind(?<constraintInd>[12])_(?<constraintValue>blank|[a-z0-9])_ind(?<targetInd>[12])$",
     Pattern.CASE_INSENSITIVE);
 
+  // Constrained-field form, no subfield (e.g. marc_245_ind1_0): the whole field, restricted to occurrences whose
+  // indicator is fixed to a value. The target is the field value (not the indicator), so this behaves like a
+  // value field with an indicator constraint -- enabling "field 245 exists with ind1 = 0". Data-field tags only.
+  private static final Pattern CONSTRAINED_FIELD_PATTERN = Pattern.compile(
+    "^marc_(?<tag>\\d{3})_ind(?<indicator>[12])_(?<indValue>blank|[a-z0-9])$",
+    Pattern.CASE_INSENSITIVE);
+
+  // Two-indicator constrained-field form, no subfield (e.g. marc_245_ind1_1_ind2_2): the whole field with both
+  // indicators fixed (canonical ind1-then-ind2 order). Data-field tags only.
+  private static final Pattern DUAL_INDICATOR_FIELD_PATTERN = Pattern.compile(
+    "^marc_(?<tag>\\d{3})_ind1_(?<ind1>blank|[a-z0-9])_ind2_(?<ind2>blank|[a-z0-9])$",
+    Pattern.CASE_INSENSITIVE);
+
   // Generic scanner for JSON field-name keys in a raw FQL query. It intentionally does NOT encode the MARC
   // grammar. Every candidate key is validated through parse()/isMarcFieldName, so the grammar lives in one place.
   // The class allows dots so composite-prefixed keys (marc_bib.marc_245_a) are captured whole, not truncated.
@@ -128,6 +141,28 @@ public class MarcFieldFactory {
         constrainedMatcher.group("subfield"),
         constrainedMatcher.group("indicator"),
         normalizeIndicatorValue(constrainedMatcher.group("indValue"))));
+    }
+
+    // Two indicators constrained, no subfield (marc_245_ind1_1_ind2_2): whole field with both indicators fixed.
+    Matcher dualFieldMatcher = DUAL_INDICATOR_FIELD_PATTERN.matcher(core);
+    if (dualFieldMatcher.matches() && !isControlFieldTag(dualFieldMatcher.group("tag"))) {
+      return Optional.of(dualIndicatorField(
+        fieldName,
+        source,
+        dualFieldMatcher.group("tag"),
+        normalizeIndicatorValue(dualFieldMatcher.group("ind1")),
+        normalizeIndicatorValue(dualFieldMatcher.group("ind2"))));
+    }
+
+    // One indicator constrained, no subfield (marc_245_ind1_1): whole field with one indicator fixed.
+    Matcher constrainedFieldMatcher = CONSTRAINED_FIELD_PATTERN.matcher(core);
+    if (constrainedFieldMatcher.matches() && !isControlFieldTag(constrainedFieldMatcher.group("tag"))) {
+      return Optional.of(constrainedField(
+        fieldName,
+        source,
+        constrainedFieldMatcher.group("tag"),
+        constrainedFieldMatcher.group("indicator"),
+        normalizeIndicatorValue(constrainedFieldMatcher.group("indValue"))));
     }
 
     // Indicator target with the other indicator constrained (marc_245_ind1_1_ind2 / marc_245_ind2_1_ind1).
@@ -196,6 +231,21 @@ public class MarcFieldFactory {
     return new MarcFieldName(fieldName, source, tag, null,
       indicatorSlotValue("1", constraintIndicator, constraintValue),
       indicatorSlotValue("2", constraintIndicator, constraintValue), targetIndicator);
+  }
+
+  // Whole-field value with one indicator constrained, no subfield (marc_245_ind1_0): no target indicator, so it
+  // behaves like a value field narrowed to occurrences whose indicator matches.
+  private static MarcFieldName constrainedField(String fieldName, String source, String tag,
+                                                String constraintIndicator, String constraintValue) {
+    return new MarcFieldName(fieldName, source, tag, null,
+      indicatorSlotValue("1", constraintIndicator, constraintValue),
+      indicatorSlotValue("2", constraintIndicator, constraintValue), null);
+  }
+
+  // Whole-field value with both indicators constrained, no subfield (marc_245_ind1_1_ind2_2).
+  private static MarcFieldName dualIndicatorField(String fieldName, String source, String tag,
+                                                  String ind1Value, String ind2Value) {
+    return new MarcFieldName(fieldName, source, tag, null, ind1Value, ind2Value, null);
   }
 
   // The value for indicator slot ("1"/"2") when a single indicator is constrained; null for the other slot.

--- a/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
+++ b/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
@@ -77,7 +77,7 @@ class MarcFieldFactoryTest {
     // multi-indicator: one indicator constrained, the other is the target
     "marc_245_ind1_1_ind2,           245, ,        1,    ,     2,      MARC 245 ind1=1 ind2",
     "marc_245_ind2_1_ind1,           245, ,        ,     1,    1,      MARC 245 ind2=1 ind1",
-    // whole-field value with indicator constraint(s), no subfield (no target)
+    // whole-field value with indicator constraint(s), no subfield
     "marc_245_ind1_0,                245, ,        0,    ,     ,       MARC 245 ind1=0",
     "marc_245_ind2_1,                245, ,        ,     1,    ,       MARC 245 ind2=1",
     "marc_245_ind1_blank,            245, ,        #,    ,     ,       MARC 245 ind1=blank",

--- a/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
+++ b/src/test/java/org/folio/fql/service/MarcFieldFactoryTest.java
@@ -76,7 +76,12 @@ class MarcFieldFactoryTest {
     "marc_041_ind1_1_ind2_7_2,       041, 2,       1,    7,    ,       MARC 041 ind1=1 ind2=7 $2",
     // multi-indicator: one indicator constrained, the other is the target
     "marc_245_ind1_1_ind2,           245, ,        1,    ,     2,      MARC 245 ind1=1 ind2",
-    "marc_245_ind2_1_ind1,           245, ,        ,     1,    1,      MARC 245 ind2=1 ind1"
+    "marc_245_ind2_1_ind1,           245, ,        ,     1,    1,      MARC 245 ind2=1 ind1",
+    // whole-field value with indicator constraint(s), no subfield (no target)
+    "marc_245_ind1_0,                245, ,        0,    ,     ,       MARC 245 ind1=0",
+    "marc_245_ind2_1,                245, ,        ,     1,    ,       MARC 245 ind2=1",
+    "marc_245_ind1_blank,            245, ,        #,    ,     ,       MARC 245 ind1=blank",
+    "marc_245_ind1_1_ind2_2,         245, ,        1,    2,    ,       MARC 245 ind1=1 ind2=2"
   })
   void shouldParseSupportedForms(String fieldName, String tag, String subfield, String ind1, String ind2,
                                  String target, String labelAlias) {
@@ -133,6 +138,9 @@ class MarcFieldFactoryTest {
     "marc_008_ind1_7_a",          // control field cannot use a constrained subfield
     "marc_008_ind1_1_ind2_2_a",   // control field cannot use a dual-indicator subfield
     "marc_008_ind1_1_ind2",       // control field cannot use a constrained indicator-target
+    "marc_245_ind1_ab",           // constrained field: multi-char indicator value
+    "marc_008_ind1_0",            // control field cannot use a constrained field
+    "marc_008_ind1_1_ind2_2",     // control field cannot use a dual-indicator constrained field
     "marc_",               // no tag
     "not_a_marc_field"
   })
@@ -154,6 +162,8 @@ class MarcFieldFactoryTest {
     "marc_245_ind2_1_ind1, true",    // mirror
     "marc_245_ind1_7_a, false",      // constrained subfield targets the subfield
     "marc_245_ind1_1_ind2_2_a, false", // both constrained, subfield is the target
+    "marc_245_ind1_0, false",        // constrained field, no target
+    "marc_245_ind1_1_ind2_2, false", // dual constrained field, no target
     "marc_245_a, false",
     "marc_245, false"
   })


### PR DESCRIPTION
[LIBFQMQUER-21](https://folio-org.atlassian.net/browse/LIBFQMQUER-21): Support indicator-constrained MARC field queries without a subfield - #64